### PR TITLE
Implement Dashed Rectangles with Offsets

### DIFF
--- a/src/D2DLibExport/D2DDevice.cs
+++ b/src/D2DLibExport/D2DDevice.cs
@@ -62,6 +62,11 @@ namespace unvell.D2DLib
 			HANDLE handle = D2D.CreatePen(this.Handle, color, dashStyle);
 			return handle == HANDLE.Zero ? null : new D2DPen(handle, color, dashStyle);
 		}
+		public D2DPen CreateCustomPen(D2DColor color, float[] dashes)
+		{
+			HANDLE handle = D2D.CreatePen(this.Handle, color, D2DDashStyle.Custom, dashes, (uint)dashes.Length);
+			return handle == HANDLE.Zero ? null : new D2DPen(handle, color, D2DDashStyle.Custom);
+		}
 
 		public D2DSolidColorBrush CreateSolidColorBrush(D2DColor color)
 		{

--- a/src/D2DLibExport/D2DDevice.cs
+++ b/src/D2DLibExport/D2DDevice.cs
@@ -57,15 +57,22 @@ namespace unvell.D2DLib
 			if (Handle != HANDLE.Zero) D2D.ResizeContext(this.Handle);
 		}
 
-		public D2DPen CreatePen(D2DColor color, D2DDashStyle dashStyle)
+		public D2DPen CreatePen(D2DColor color, D2DDashStyle dashStyle, float dashOffset = 0.0f)
 		{
-			HANDLE handle = D2D.CreatePen(this.Handle, color, dashStyle);
+			HANDLE handle = D2D.CreatePen(this.Handle, color, dashStyle, null, 0, dashOffset);
 			return handle == HANDLE.Zero ? null : new D2DPen(handle, color, dashStyle);
 		}
-		public D2DPen CreateCustomPen(D2DColor color, float[] dashes)
+		public D2DPen CreateCustomPen(D2DColor color, float[] dashes, float dashOffset = 0.0f)
 		{
-			HANDLE handle = D2D.CreatePen(this.Handle, color, D2DDashStyle.Custom, dashes, (uint)dashes.Length);
+			if (dashes == null) throw new ArgumentNullException(nameof(dashes));
+
+			HANDLE handle = D2D.CreatePen(this.Handle, color, D2DDashStyle.Custom, dashes, (uint)dashes.Length, dashOffset);
 			return handle == HANDLE.Zero ? null : new D2DPen(handle, color, D2DDashStyle.Custom);
+		}
+		public void DestroyPen(D2DPen pen)
+		{
+			if (pen == null) throw new ArgumentNullException(nameof(pen));
+			D2D.DestroyPen(pen.Handle);
 		}
 
 		public D2DSolidColorBrush CreateSolidColorBrush(D2DColor color)

--- a/src/D2DLibExport/D2DGraphics.cs
+++ b/src/D2DLibExport/D2DGraphics.cs
@@ -286,6 +286,11 @@ namespace unvell.D2DLib
 			this.DrawRectangle(new D2DRect(origin, size), color, strokeWidth, dashStyle);
 		}
 
+		public void DrawRectangle(D2DRect rect, D2DPen strokePen, FLOAT strokeWidth = 1)
+		{
+			D2D.DrawRectangleWithPen(this.DeviceHandle, ref rect, strokePen.Handle, strokeWidth);
+		}
+
 		public void FillRectangle(float x, float y, float width, float height, D2DColor color)
 		{
 			var rect = new D2DRect(x, y, width, height);

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -145,6 +145,9 @@ namespace unvell.D2DLib
 			FLOAT weight = 1, D2DDashStyle dashStyle = D2DDashStyle.Solid);
 
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+		public static extern void DrawRectangleWithPen(HANDLE context, ref D2DRect rect, HANDLE strokePen, FLOAT weight = 1);
+
+		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void FillRectangle(HANDLE context, ref D2DRect rect, D2DColor color);
 
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
@@ -246,7 +249,7 @@ namespace unvell.D2DLib
 
 		#region Pen
 		[DllImport(DLL_NAME, EntryPoint = "CreatePenStroke")]
-		public static extern HANDLE CreatePen(HANDLE ctx, D2DColor strokeColor, D2DDashStyle dashStyle = D2DDashStyle.Solid);
+		public static extern HANDLE CreatePen(HANDLE ctx, D2DColor strokeColor, D2DDashStyle dashStyle = D2DDashStyle.Solid, FLOAT[] dashes = null, UINT dashCount = 0);
 
 		[DllImport(DLL_NAME, EntryPoint = "DestroyPenStroke")]
 		public static extern void DestroyPen(HANDLE pen);

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -249,7 +249,8 @@ namespace unvell.D2DLib
 
 		#region Pen
 		[DllImport(DLL_NAME, EntryPoint = "CreatePenStroke")]
-		public static extern HANDLE CreatePen(HANDLE ctx, D2DColor strokeColor, D2DDashStyle dashStyle = D2DDashStyle.Solid, FLOAT[] dashes = null, UINT dashCount = 0);
+		public static extern HANDLE CreatePen(HANDLE ctx, D2DColor strokeColor, D2DDashStyle dashStyle = D2DDashStyle.Solid,
+			FLOAT[] dashes = null, UINT dashCount = 0, FLOAT dashOffset = 0.0f);
 
 		[DllImport(DLL_NAME, EntryPoint = "DestroyPenStroke")]
 		public static extern void DestroyPen(HANDLE pen);

--- a/src/Examples/Demos/Whiteboard.cs
+++ b/src/Examples/Demos/Whiteboard.cs
@@ -106,6 +106,12 @@ namespace unvell.D2DLib.Examples.Demos
 
 			// draw cursor
 			this.drawCursor(g, this.cursorPoint);
+
+			if (this.penColor == D2DColor.White)
+			{
+				// when we're in the eraser, we want to invalidate since the eraser is animated
+				this.Invalidate();
+			}
 		}
 
 		protected override void OnMouseDown(MouseEventArgs e)
@@ -214,12 +220,22 @@ namespace unvell.D2DLib.Examples.Demos
 			this.lastPoint = currentPoint;
 		}
 
+
+		private readonly float[] eraserPenDashes = new[] { 2f, 2f };
+		private float eraserDashOffset = 0.0f;
 		private void drawCursor(D2DGraphics g, Point p)
 		{
 			if (this.penColor == D2DColor.White)
 			{
 				// when current color is white, draw an eraser
-				g.DrawRectangle(p.X - this.penSize.Width, p.Y - this.penSize.Height, this.penSize.Width * 2, this.penSize.Height * 2, D2DColor.Black, 2);
+				var eraserRectangle = new D2DRect(p.X - this.penSize.Width, p.Y - this.penSize.Height, this.penSize.Width * 2, this.penSize.Height * 2);
+
+				var pen = Device.CreateCustomPen(D2DColor.Black, eraserPenDashes, eraserDashOffset);
+
+				g.DrawRectangle(eraserRectangle, pen, 2);
+
+				Device.DestroyPen(pen);
+				eraserDashOffset += 0.1f;
 			}
 			else
 			{

--- a/src/d2dlib/Brush.cpp
+++ b/src/d2dlib/Brush.cpp
@@ -25,7 +25,7 @@
 #include "stdafx.h"
 #include "Brush.h"
 
-HANDLE CreateStorkeStyle(HANDLE ctx, FLOAT* dashes, UINT dashCount)
+HANDLE CreateStrokeStyle(HANDLE ctx, FLOAT* dashes, UINT dashCount)
 {
 	RetrieveContext(ctx);
 
@@ -37,7 +37,7 @@ HANDLE CreateStorkeStyle(HANDLE ctx, FLOAT* dashes, UINT dashCount)
             D2D1_CAP_STYLE_ROUND,
             D2D1_LINE_JOIN_MITER,
             10.0f,
-						D2D1_DASH_STYLE_CUSTOM,
+            D2D1_DASH_STYLE_CUSTOM,
             0.0f), dashes, dashCount, &strokeStyle);
 
 	return (HANDLE)strokeStyle;

--- a/src/d2dlib/Geometry.cpp
+++ b/src/d2dlib/Geometry.cpp
@@ -168,7 +168,7 @@ void DrawPath(HANDLE pathCtx, D2D1_COLOR_F strokeColor, FLOAT strokeWidth, D2D1_
           D2D1_CAP_STYLE_ROUND,
           D2D1_LINE_JOIN_MITER,
           10.0f,
-					dashStyle,
+          dashStyle,
           0.0f), NULL, 0, &strokeStyle);
 	}
 

--- a/src/d2dlib/Pen.cpp
+++ b/src/d2dlib/Pen.cpp
@@ -25,7 +25,7 @@
 #include "stdafx.h"
 #include "Pen.h"
 
-D2DLIB_API HANDLE CreatePenStroke(HANDLE ctx, D2D1_COLOR_F color, D2D1_DASH_STYLE dashStyle)
+D2DLIB_API HANDLE CreatePenStroke(HANDLE ctx, D2D1_COLOR_F color, D2D1_DASH_STYLE dashStyle, FLOAT* dashes, UINT dashCount)
 {
 	RetrieveContext(ctx);
 
@@ -43,7 +43,7 @@ D2DLIB_API HANDLE CreatePenStroke(HANDLE ctx, D2D1_COLOR_F color, D2D1_DASH_STYL
 			D2D1_LINE_JOIN_MITER,
 			10.0f,
 			dashStyle,
-			0.0f), NULL, 0, &strokeStyle);
+			0.0f), dashes, dashCount, &strokeStyle);
 	}
 
 	D2DPen* pen = new D2DPen();

--- a/src/d2dlib/Pen.cpp
+++ b/src/d2dlib/Pen.cpp
@@ -25,7 +25,7 @@
 #include "stdafx.h"
 #include "Pen.h"
 
-D2DLIB_API HANDLE CreatePenStroke(HANDLE ctx, D2D1_COLOR_F color, D2D1_DASH_STYLE dashStyle, FLOAT* dashes, UINT dashCount)
+D2DLIB_API HANDLE CreatePenStroke(HANDLE ctx, D2D1_COLOR_F color, D2D1_DASH_STYLE dashStyle, FLOAT* dashes, UINT dashCount, FLOAT dashOffset)
 {
 	RetrieveContext(ctx);
 
@@ -43,7 +43,7 @@ D2DLIB_API HANDLE CreatePenStroke(HANDLE ctx, D2D1_COLOR_F color, D2D1_DASH_STYL
 			D2D1_LINE_JOIN_MITER,
 			10.0f,
 			dashStyle,
-			0.0f), dashes, dashCount, &strokeStyle);
+			dashOffset), dashes, dashCount, &strokeStyle);
 	}
 
 	D2DPen* pen = new D2DPen();

--- a/src/d2dlib/Pen.h
+++ b/src/d2dlib/Pen.h
@@ -35,7 +35,8 @@ typedef struct D2DPen
 extern "C"
 {
 	D2DLIB_API HANDLE CreatePenStroke(HANDLE context, D2D1_COLOR_F color,
-		D2D1_DASH_STYLE dashStyle = D2D1_DASH_STYLE::D2D1_DASH_STYLE_SOLID);
+		D2D1_DASH_STYLE dashStyle = D2D1_DASH_STYLE::D2D1_DASH_STYLE_SOLID,
+		FLOAT* dashes = NULL, UINT dashCount = 0);
 
 	D2DLIB_API void DestroyPenStroke(HANDLE pen);
 }

--- a/src/d2dlib/Pen.h
+++ b/src/d2dlib/Pen.h
@@ -36,7 +36,7 @@ extern "C"
 {
 	D2DLIB_API HANDLE CreatePenStroke(HANDLE context, D2D1_COLOR_F color,
 		D2D1_DASH_STYLE dashStyle = D2D1_DASH_STYLE::D2D1_DASH_STYLE_SOLID,
-		FLOAT* dashes = NULL, UINT dashCount = 0);
+		FLOAT* dashes = NULL, UINT dashCount = 0, FLOAT dashOffset = 0.0f);
 
 	D2DLIB_API void DestroyPenStroke(HANDLE pen);
 }

--- a/src/d2dlib/Simple.cpp
+++ b/src/d2dlib/Simple.cpp
@@ -183,6 +183,18 @@ void DrawRectangle(HANDLE ctx, D2D1_RECT_F* rect, D2D1_COLOR_F color,
 	SafeRelease(&strokeStyle);
 }
 
+
+void DrawRectangleWithPen(HANDLE ctx, D2D1_RECT_F* rect, HANDLE strokePen, FLOAT width)
+{
+	RetrieveContext(ctx);
+
+	D2DPen* pen = reinterpret_cast<D2DPen*>(strokePen);
+
+	if (pen->brush != NULL) {
+		context->renderTarget->DrawRectangle(rect, pen->brush, width, pen->strokeStyle);
+	}
+}
+
 void FillRectangle(HANDLE ctx, D2D1_RECT_F* rect, D2D1_COLOR_F color)
 {
 	RetrieveContext(ctx);

--- a/src/d2dlib/Simple.h
+++ b/src/d2dlib/Simple.h
@@ -39,6 +39,8 @@ extern "C"
 	D2DLIB_API void DrawRectangle(HANDLE ctx, D2D1_RECT_F* rect, D2D1_COLOR_F color,
 		FLOAT width = 1, D2D1_DASH_STYLE dashStyle = D2D1_DASH_STYLE::D2D1_DASH_STYLE_SOLID);
 
+	D2DLIB_API void DrawRectangleWithPen(HANDLE ctx, D2D1_RECT_F* rect, HANDLE strokePen, FLOAT width = 1);
+
 	D2DLIB_API void FillRectangle(HANDLE ctx, D2D1_RECT_F* rect, D2D1_COLOR_F color);
 
 	D2DLIB_API void FillRectangleWithBrush(HANDLE ctx, D2D1_RECT_F* rect, HANDLE brushHandle);


### PR DESCRIPTION
I tried to implement #28.

You can see a demo of the dashed rectangles in the whiteboard example. The eraser has now a dashed outline which is animated (by its offset).

Feel free to request changes, I'll try my best.

Resolves #28