### PR TITLE
Fix consumption of package for .NET Core and .NET 5

### DIFF
--- a/package/unvell.D2DLib.nuspec
+++ b/package/unvell.D2DLib.nuspec
@@ -15,7 +15,7 @@
     <description>Provides the hardware-accelerated high performance immediate mode rendering functionality via Direct2D API.</description>
     <summary>Provides the hardware-accelerated high performance immediate mode rendering functionality via Direct2D API.</summary>
     <copyright>Copyright (c) 2012-2019 Jingwood, unvell.com, all rights reserved.</copyright>
-    <tags>direct2d hardward-acceleration drawing draw custom-draw rendering paint gpu performance immediate bitmap memory-bitmap direct2d-api graphics-context</tags>
+    <tags>direct2d hardware-acceleration drawing draw custom-draw rendering paint gpu performance immediate bitmap memory-bitmap direct2d-api graphics-context</tags>
     <dependencies>
       <group targetFramework="net20">
       </group>

--- a/package/unvell.D2DLib.nuspec
+++ b/package/unvell.D2DLib.nuspec
@@ -17,18 +17,16 @@
     <copyright>Copyright (c) 2012-2019 Jingwood, unvell.com, all rights reserved.</copyright>
     <tags>direct2d hardware-acceleration drawing draw custom-draw rendering paint gpu performance immediate bitmap memory-bitmap direct2d-api graphics-context</tags>
     <dependencies>
-      <group targetFramework="net20">
-      </group>
-      <group targetFramework="netcore">
-      </group>
+      <group targetFramework="net20" />
+      <group targetFramework="netstandard1.0" />
     </dependencies>
   </metadata>
   <files>
     <file src="logo_d2dlib.png" target="" />
     <file src="..\binary\x86-build\d2dlibexport.dll" target="lib\net20" />
     <file src="..\binary\x86-build\d2dwinform.dll" target="lib\net20" />
-    <file src="..\binary\x86-build\d2dlibexport.dll" target="lib\netcore" />
-    <file src="..\binary\x86-build\d2dwinform.dll" target="lib\netcore" />
+    <file src="..\binary\x86-build\d2dlibexport.dll" target="lib\netstandard1.0" />
+    <file src="..\binary\x86-build\d2dwinform.dll" target="lib\netstandard1.0" />
     <file src="..\binary\x86-build\d2dlib32.dll" target="build" />
     <file src="unvell.D2DLib.targets" target="build" />
     <file src="..\README.md" target="" />


### PR DESCRIPTION
Fixes #38

`netcore` is not a valid `targetFramework` value, so was being ignored by NuGet during package resolve.

Using `netstandard1.0` instead will ensure the package's files are referenced by the project correctly in .NET Core and .NET 5 projects.

---

I packed the package locally to test and verified the fix for both `netcoreapp3.1` and `net5.0-windows` projects.