### PR TITLE
Fix `ShowFPS` of `D2DControl` and some performance improvement

### DIFF
--- a/src/D2DWinForm/D2DControl.cs
+++ b/src/D2DWinForm/D2DControl.cs
@@ -49,7 +49,7 @@ namespace unvell.D2DLib.WinForm
 		private int currentFps = 0;
 		private int lastFps = 0;
 		public bool ShowFPS { get; set; }
-		private DateTime lastFpsUpdate = DateTime.Now;
+		private DateTime lastFpsUpdate = DateTime.UtcNow;
 
 		protected override void CreateHandle()
 		{
@@ -101,10 +101,11 @@ namespace unvell.D2DLib.WinForm
 			
 			if (ShowFPS)
 			{
-				if (this.lastFpsUpdate.Second != DateTime.Now.Second)
+				if (this.lastFpsUpdate.Second != DateTime.UtcNow.Second)
 				{
 					this.lastFps = this.currentFps;
 					this.currentFps = 0;
+					this.lastFpsUpdate = DateTime.UtcNow;
 				}
 				else
 				{

--- a/src/D2DWinForm/D2DWinForm.cs
+++ b/src/D2DWinForm/D2DWinForm.cs
@@ -67,7 +67,7 @@ namespace unvell.D2DLib.WinForm
 		private int currentFps = 0;
 		private int lastFps = 0;
 		public bool ShowFPS { get; set; }
-		private DateTime lastFpsUpdate = DateTime.Now;
+		private DateTime lastFpsUpdate = DateTime.UtcNow;
 
 		private Timer timer = new Timer() { Interval = 10 };
 		public bool EscapeKeyToClose { get; set; } = true;
@@ -145,11 +145,11 @@ namespace unvell.D2DLib.WinForm
 
 				if (ShowFPS)
 				{
-					if (this.lastFpsUpdate.Second != DateTime.Now.Second)
+					if (this.lastFpsUpdate.Second != DateTime.UtcNow.Second)
 					{
 						this.lastFps = this.currentFps;
 						this.currentFps = 0;
-						this.lastFpsUpdate = DateTime.Now;
+						this.lastFpsUpdate = DateTime.UtcNow;
 					}
 					else
 					{


### PR DESCRIPTION
This PR fixes a missing assignment of `lastFpsUpdate` in `D2DControl` and also improves performance of showing the fps by using `DateTime.UtcNow` instead of `DateTime.Now`.

#### Some benchmarks to show the performance improvements

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1387 (21H1/May2021Update)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 5.0.12 (5.0.1221.52207), X64 RyuJIT
  Job-FPINJZ : .NET 5.0.12 (5.0.1221.52207), X64 RyuJIT
  Job-IQQFOL : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  Job-OFJKZZ : .NET Framework 4.8 (4.8.4420.0), X64 RyuJIT

Force=True  

```
| Method |            Runtime | Runs |         Mean |      Error |     StdDev | Ratio | Allocated |
|------- |------------------- |----- |-------------:|-----------:|-----------:|------:|----------:|
|    **Now** |           **.NET 5.0** |    **1** |    **204.26 ns** |   **1.312 ns** |   **1.227 ns** |  **1.00** |         **-** |
| UtcNow |           .NET 5.0 |    1 |     74.39 ns |   0.697 ns |   0.618 ns |  0.36 |         - |
|        |                    |      |              |            |            |       |           |
|    Now |           .NET 6.0 |    1 |    136.24 ns |   2.503 ns |   2.782 ns |  1.00 |         - |
| UtcNow |           .NET 6.0 |    1 |     26.20 ns |   0.295 ns |   0.261 ns |  0.19 |         - |
|        |                    |      |              |            |            |       |           |
|    Now | .NET Framework 4.8 |    1 |    265.86 ns |   5.322 ns |   5.915 ns |  1.00 |         - |
| UtcNow | .NET Framework 4.8 |    1 |     67.75 ns |   1.379 ns |   1.588 ns |  0.26 |         - |
|        |                    |      |              |            |            |       |           |
|    **Now** |           **.NET 5.0** |  **100** | **20,321.98 ns** | **182.166 ns** | **170.399 ns** |  **1.00** |         **-** |
| UtcNow |           .NET 5.0 |  100 |  7,436.71 ns |  80.009 ns |  74.841 ns |  0.37 |         - |
|        |                    |      |              |            |            |       |           |
|    Now |           .NET 6.0 |  100 | 11,260.58 ns | 209.422 ns | 241.171 ns |  1.00 |         - |
| UtcNow |           .NET 6.0 |  100 |  2,719.37 ns |  49.646 ns |  46.439 ns |  0.24 |         - |
|        |                    |      |              |            |            |       |           |
|    Now | .NET Framework 4.8 |  100 | 26,292.46 ns | 284.250 ns | 251.980 ns |  1.00 |         - |
| UtcNow | .NET Framework 4.8 |  100 |  6,745.38 ns | 133.738 ns | 125.098 ns |  0.26 |         - |


```csharp
[Params(1, 100)]
public int Runs { get; set; }

[Benchmark(Baseline = true)]
public void Now()
{
    for (int i = 0; i < Runs; i++)
    {
        _ = System.DateTime.Now;
    }
}

[Benchmark]
public void UtcNow()
{
    for (int i = 0; i < Runs; i++)
    {
        _ = System.DateTime.UtcNow;
    }
}
```