### PR TITLE
migrate to .NET 4.6.2

### DIFF
--- a/src/D2DLibExport/D2DLibExport.csproj
+++ b/src/D2DLibExport/D2DLibExport.csproj
@@ -3,13 +3,13 @@
   <Import Project="..\NativeLibraries.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net4.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>unvell.D2DLib</RootNamespace>
     <AssemblyName>d2dlibexport</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.7.1" Condition="'$(TargetFramework)' == 'netstandard2.1'" PrivateAssets="all" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/D2DLibExport/D2DLibExport.csproj
+++ b/src/D2DLibExport/D2DLibExport.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/D2DLibExport/D2DLibExport.csproj
+++ b/src/D2DLibExport/D2DLibExport.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\NativeLibraries.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <RootNamespace>unvell.D2DLib</RootNamespace>
     <AssemblyName>d2dlibexport</AssemblyName>
   </PropertyGroup>

--- a/src/D2DWinForm/D2DWinForm.csproj
+++ b/src/D2DWinForm/D2DWinForm.csproj
@@ -4,7 +4,7 @@
   
   <!-- Build properties -->
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>unvell.D2DLib.WinForm</RootNamespace>
     <AssemblyName>d2dwinform</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/D2DWinForm/D2DWinForm.csproj
+++ b/src/D2DWinForm/D2DWinForm.csproj
@@ -4,7 +4,7 @@
   
   <!-- Build properties -->
   <PropertyGroup>
-    <TargetFrameworks>net4.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
     <RootNamespace>unvell.D2DLib.WinForm</RootNamespace>
     <AssemblyName>d2dwinform</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
     <RootNamespace>unvell.D2DLib.Examples</RootNamespace>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net4.7.2;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
     <RootNamespace>unvell.D2DLib.Examples</RootNamespace>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
@@ -9,17 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\D2DLibExport\D2DLibExport.csproj" IncludeAssets="contentFiles" />
     <ProjectReference Include="..\D2DWinForm\D2DWinForm.csproj" IncludeAssets="contentFiles" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="SampleCode\ClipMaskDraw.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="SampleCode\LineCapStyle.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Update="SampleCode\ClipMaskDraw.cs" />
+    <Compile Update="SampleCode\LineCapStyle.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\D2DLibExport\D2DLibExport.csproj" IncludeAssets="contentFiles" />
     <ProjectReference Include="..\D2DWinForm\D2DWinForm.csproj" IncludeAssets="contentFiles" />
   </ItemGroup>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0-windows</TargetFrameworks>
     <RootNamespace>unvell.D2DLib.Examples</RootNamespace>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/d2dlib/D2DLib.vcxproj
+++ b/src/d2dlib/D2DLib.vcxproj
@@ -34,7 +34,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>
     </PreferredToolArchitecture>

--- a/src/d2dlib/D2DLib.vcxproj
+++ b/src/d2dlib/D2DLib.vcxproj
@@ -28,7 +28,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -42,14 +42,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
- Change to Visual Studio 2022 C++ SDK (v142 to v143)
- ~Change to .NET 6.0~ Change .NET 4.0 to .NET 4.6.2 (since .NET 4.0 seems no longer supported)