### PR TITLE
Add parameter to PushLayer for changing opacity

### DIFF
--- a/src/D2DLibExport/D2DGraphics.cs
+++ b/src/D2DLibExport/D2DGraphics.cs
@@ -247,8 +247,9 @@ namespace unvell.D2DLib
       return PushLayer(layer, rectBounds, geometry);
     }
 
-    public D2DLayer PushLayer(D2DLayer layer, D2DRect rectBounds, D2DGeometry geometry = null) {
-      D2D.PushLayer(this.Handle, layer.Handle, ref rectBounds, geometry != null ? geometry.Handle : IntPtr.Zero);
+    public D2DLayer PushLayer(D2DLayer layer, D2DRect rectBounds, D2DGeometry geometry = null, D2DBrush opacityBrush = null)
+    {
+      D2D.PushLayer(this.Handle, layer.Handle, ref rectBounds, geometry != null ? geometry.Handle : IntPtr.Zero, opacityBrush != null ? opacityBrush.Handle : IntPtr.Zero);
       return layer;
     }
 

--- a/src/d2dlib/Brush.cpp
+++ b/src/d2dlib/Brush.cpp
@@ -50,7 +50,7 @@ HANDLE CreateSolidColorBrush(HANDLE ctx, D2D1_COLOR_F color)
 	ID2D1SolidColorBrush* brush;
 	context->renderTarget->CreateSolidColorBrush(color, &brush);
 	
-	BrushContext* brushContext = new BrushContext();
+	D2DBrushContext* brushContext = new D2DBrushContext();
 	brushContext->context = context;
 	brushContext->type = BrushType::BrushType_SolidBrush;
 	brushContext->brush = brush;
@@ -60,7 +60,7 @@ HANDLE CreateSolidColorBrush(HANDLE ctx, D2D1_COLOR_F color)
 
 void SetSolidColorBrushColor(HANDLE brushHandle, D2D1_COLOR_F color)
 {
-	BrushContext* brushContext = reinterpret_cast<BrushContext*>(brushHandle);
+	D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(brushHandle);
 	ID2D1SolidColorBrush* brush = reinterpret_cast<ID2D1SolidColorBrush*>(brushContext->brush);
 	brush->SetColor(color);
 }
@@ -77,7 +77,7 @@ HANDLE CreateLinearGradientBrush(HANDLE ctx, D2D1_POINT_2F startPoint, D2D1_POIN
 	hr = renderTarget->CreateGradientStopCollection(gradientStops, gradientStopCount, &gradientStopCollection);
 
 	ID2D1LinearGradientBrush* brush = NULL;
-	BrushContext* brushContext = NULL;
+	D2DBrushContext* brushContext = NULL;
 
 	if (SUCCEEDED(hr))
 	{
@@ -85,7 +85,7 @@ HANDLE CreateLinearGradientBrush(HANDLE ctx, D2D1_POINT_2F startPoint, D2D1_POIN
 			D2D1::LinearGradientBrushProperties(startPoint, endPoint), gradientStopCollection, &brush);
 
 		if (SUCCEEDED(hr)) {
-			brushContext = new BrushContext();
+			brushContext = new D2DBrushContext();
 			brushContext->context = context;
 			brushContext->type = BrushType::BrushType_LinearGradientBrush;
 			brushContext->brush = brush;
@@ -110,7 +110,7 @@ HANDLE CreateRadialGradientBrush(HANDLE ctx, D2D1_POINT_2F origin, D2D1_POINT_2F
 		gradientStops, gradientStopCount, &gradientStopCollection);
 	
 	ID2D1RadialGradientBrush* brush = NULL;
-	BrushContext* brushContext = NULL;
+	D2DBrushContext* brushContext = NULL;
 
 	if (SUCCEEDED(hr)) 
 	{
@@ -118,7 +118,7 @@ HANDLE CreateRadialGradientBrush(HANDLE ctx, D2D1_POINT_2F origin, D2D1_POINT_2F
 			origin, offset, radiusX, radiusY), gradientStopCollection, &brush);
 
 		if (SUCCEEDED(hr)) {
-			brushContext = new BrushContext();
+			brushContext = new D2DBrushContext();
 			brushContext->context = context;
 			brushContext->type = BrushType::BrushType_RadialGradientBrush;
 			brushContext->brush = brush;
@@ -131,7 +131,7 @@ HANDLE CreateRadialGradientBrush(HANDLE ctx, D2D1_POINT_2F origin, D2D1_POINT_2F
 
 void ReleaseBrush(HANDLE brushHandle)
 {
-	BrushContext* brushContext = reinterpret_cast<BrushContext*>(brushHandle);
+	D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(brushHandle);
 
 	switch (brushContext->type)
 	{

--- a/src/d2dlib/Brush.h
+++ b/src/d2dlib/Brush.h
@@ -26,21 +26,6 @@
 
 #include "Context.h"
 
-enum BrushType {
-	BrushType_SolidBrush,
-	BrushType_LinearGradientBrush,
-	BrushType_RadialGradientBrush,
-};
-
-struct BrushContext {
-	D2DContext* context;
-	ID2D1Brush* brush;
-	BrushType type;
-	union {
-		ID2D1GradientStopCollection* gradientStops = NULL;
-	};
-};
-
 extern "C"
 {
 	D2DLIB_API HANDLE CreateSolidColorBrush(HANDLE ctx, D2D1_COLOR_F color);

--- a/src/d2dlib/Context.cpp
+++ b/src/d2dlib/Context.cpp
@@ -310,19 +310,24 @@ HANDLE CreateLayer(HANDLE ctx)
 }
 
 void PushLayer(HANDLE ctx, HANDLE layerHandle, D2D1_RECT_F& contentBounds, __in_opt HANDLE geometryHandle,
-		__in_opt ID2D1Brush* opacityBrush, D2D1_LAYER_OPTIONS layerOptions)
+		__in_opt HANDLE opacityBrush, D2D1_LAYER_OPTIONS layerOptions)
 {
 	RetrieveContext(ctx);
 
 	ID2D1Geometry* geometry = NULL;
-
 	if (geometryHandle != NULL) {
 		D2DGeometryContext* geometryContext = reinterpret_cast<D2DGeometryContext*>(geometryHandle);
 		geometry = geometryContext->geometry;
 	}
 
+	ID2D1Brush* brush = NULL;
+	if (opacityBrush != NULL) {
+		D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(opacityBrush);
+		brush = brushContext->brush;
+	}
+
 	D2D1_LAYER_PARAMETERS params = D2D1::LayerParameters(contentBounds, geometry,
-		D2D1_ANTIALIAS_MODE_PER_PRIMITIVE, D2D1::IdentityMatrix(), 1, opacityBrush, layerOptions);
+		D2D1_ANTIALIAS_MODE_PER_PRIMITIVE, D2D1::IdentityMatrix(), 1, brush, layerOptions);
 
 	ID2D1Layer* layer = reinterpret_cast<ID2D1Layer*>(layerHandle);
 	context->renderTarget->PushLayer(&params, layer);

--- a/src/d2dlib/Context.h
+++ b/src/d2dlib/Context.h
@@ -74,6 +74,21 @@ typedef struct D2DGeometryContext {
 	ID2D1Geometry* geometry;
 } D2DGeometryContext;
 
+enum BrushType {
+	BrushType_SolidBrush,
+	BrushType_LinearGradientBrush,
+	BrushType_RadialGradientBrush,
+};
+
+struct D2DBrushContext {
+	D2DContext* context;
+	ID2D1Brush* brush;
+	BrushType type;
+	union {
+		ID2D1GradientStopCollection* gradientStops = NULL;
+	};
+};
+
 typedef struct D2DPathContext : D2DGeometryContext
 {
 	ID2D1PathGeometry* path;
@@ -150,7 +165,7 @@ extern "C"
 
 	D2DLIB_API HANDLE CreateLayer(HANDLE context);
 	D2DLIB_API void PushLayer(HANDLE ctx, HANDLE layerHandle, D2D1_RECT_F& contentBounds = D2D1::InfiniteRect(),
-		__in_opt HANDLE geometryHandle = NULL, __in_opt ID2D1Brush *opacityBrush = NULL, 
+		__in_opt HANDLE geometryHandle = NULL, __in_opt HANDLE opacityBrush = NULL, 
 		D2D1_LAYER_OPTIONS layerOptions = D2D1_LAYER_OPTIONS_NONE);
 	D2DLIB_API void PopLayer(HANDLE ctx);
 

--- a/src/d2dlib/Geometry.cpp
+++ b/src/d2dlib/Geometry.cpp
@@ -304,7 +304,7 @@ void DrawPolygon(HANDLE ctx, D2D1_POINT_2F* points, UINT count,
 	}
 
 	if (fillBrush != NULL) {
-		BrushContext brushCtx;
+		D2DBrushContext brushCtx;
 		brushCtx.brush = fillBrush;
 		DrawPolygonWithBrush(ctx, points, count, strokeColor, strokeWidth, dashStyle, &brushCtx);
 		SafeRelease(&fillBrush);
@@ -339,7 +339,7 @@ void DrawPolygonWithBrush(HANDLE ctx, D2D1_POINT_2F* points, UINT count,
 
 	ID2D1Brush* brush = NULL;
 	if (brushHandle != NULL) {
-		BrushContext* brushContext = reinterpret_cast<BrushContext*>(brushHandle);
+		D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(brushHandle);
 		brush = brushContext->brush;
 		renderTarget->FillGeometry(path, brush);
 	}
@@ -379,7 +379,7 @@ void DrawPolygonWithBrush(HANDLE ctx, D2D1_POINT_2F* points, UINT count,
 void FillPathWithBrush(HANDLE ctx, HANDLE brushHandle)
 {
 	D2DPathContext* pathContext = reinterpret_cast<D2DPathContext*>(ctx);
-	BrushContext* brushContext = reinterpret_cast<BrushContext*>(brushHandle);
+	D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(brushHandle);
 	D2DContext* context = pathContext->d2context;
 
 	context->renderTarget->FillGeometry(pathContext->path, brushContext->brush);
@@ -390,8 +390,8 @@ void FillGeometryWithBrush(HANDLE ctx, HANDLE geoHandle, _In_ HANDLE brushHandle
 	RetrieveContext(ctx);
 
 	ID2D1Geometry* geometry = reinterpret_cast<ID2D1Geometry*>(geoHandle);
-	BrushContext* brushContext = reinterpret_cast<BrushContext*>(brushHandle);
-	BrushContext* opacityBrushContext = reinterpret_cast<BrushContext*>(opacityBrushHandle);
+	D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(brushHandle);
+	D2DBrushContext* opacityBrushContext = reinterpret_cast<D2DBrushContext*>(opacityBrushHandle);
 
 	context->renderTarget->FillGeometry(geometry, brushContext->brush,
 		opacityBrushContext == NULL ? NULL : opacityBrushContext->brush);

--- a/src/d2dlib/Simple.cpp
+++ b/src/d2dlib/Simple.cpp
@@ -216,7 +216,7 @@ void FillRectangleWithBrush(HANDLE ctx, D2D1_RECT_F* rect, HANDLE brushHandle)
 {
 	RetrieveContext(ctx);
 
-	BrushContext* brushContext = reinterpret_cast<BrushContext*>(brushHandle);
+	D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(brushHandle);
 	ID2D1Brush* brush = reinterpret_cast<ID2D1Brush*>(brushContext->brush);
 
 	if (brush != NULL) {
@@ -272,7 +272,7 @@ D2DLIB_API void DrawRoundedRectWithBrush(HANDLE ctx, D2D1_ROUNDED_RECT* roundedR
 	RetrieveContext(ctx);
 
 	D2DPen* pen = reinterpret_cast<D2DPen*>(strokePen);
-	BrushContext* brushContext = reinterpret_cast<BrushContext*>(fillBrush);
+	D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(fillBrush);
 	ID2D1Brush* brush = reinterpret_cast<ID2D1Brush*>(brushContext->brush);
 
 	if (pen != NULL) {
@@ -334,7 +334,7 @@ void FillEllipseWithBrush(HANDLE ctx, D2D1_ELLIPSE* ellipse, HANDLE brushHandle)
 {
 	RetrieveContext(ctx);
 
-	BrushContext* brushContext = reinterpret_cast<BrushContext*>(brushHandle);
+	D2DBrushContext* brushContext = reinterpret_cast<D2DBrushContext*>(brushHandle);
 	ID2D1Brush* brush = reinterpret_cast<ID2D1Brush*>(brushContext->brush);
 
 	context->renderTarget->FillEllipse(ellipse, brush);


### PR DESCRIPTION
It seems that the .NET export for PushLayer is not using the opacityBrush parameter that the C++ code already provides. I've added it in this PR so that you can make layers with different opacities (eg. not always opaque).