### PR TITLE
Nullable and usings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,9 +5,9 @@ root = true
 
 # Don't use tabs for indentation.
 [*.{cs,c,cpp,h,hpp}]
-indent_style = tabs
 indent_style = tab
-indent_size = 2
+indent_size = tab
+tab_width = 4
 insert_final_newline = true
 charset = utf-8-bom
 

--- a/src/D2DLibExport/Assumes.cs
+++ b/src/D2DLibExport/Assumes.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace unvell.D2DLib;
+
+internal static class Assumes
+{
+	public static void NotNull<T>([NotNull] T? value)
+	{
+		if (value is null)
+			throw new Exception($"Value of type {typeof(T).Name} cannot be null.");
+	}
+}

--- a/src/D2DLibExport/D2DBitmap.cs
+++ b/src/D2DLibExport/D2DBitmap.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
   public class D2DBitmap : D2DObject

--- a/src/D2DLibExport/D2DBitmapGraphics.cs
+++ b/src/D2DLibExport/D2DBitmapGraphics.cs
@@ -22,18 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
 	public class D2DBitmapGraphics : D2DGraphics, IDisposable

--- a/src/D2DLibExport/D2DBitmapGraphics.cs
+++ b/src/D2DLibExport/D2DBitmapGraphics.cs
@@ -31,7 +31,7 @@ namespace unvell.D2DLib
 		{
 		}
 
-		public D2DBitmap GetBitmap()
+		public D2DBitmap? GetBitmap()
 		{
 			HANDLE bitmapHandle = D2D.GetBitmapRenderTargetBitmap(this.Handle);
 			return bitmapHandle == HANDLE.Zero ? null : new D2DBitmap(bitmapHandle);

--- a/src/D2DLibExport/D2DBrush.cs
+++ b/src/D2DLibExport/D2DBrush.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
 	public abstract class D2DBrush : D2DObject

--- a/src/D2DLibExport/D2DDevice.cs
+++ b/src/D2DLibExport/D2DDevice.cs
@@ -46,7 +46,7 @@ namespace unvell.D2DLib
 			if (Handle != HANDLE.Zero) D2D.ResizeContext(this.Handle);
 		}
 
-		public D2DStrokeStyle CreateStrokeStyle(float[] dashes = null, float dashOffset = 0.0f,
+		public D2DStrokeStyle? CreateStrokeStyle(float[]? dashes = null, float dashOffset = 0.0f,
 			D2DCapStyle startCap = D2DCapStyle.Flat, D2DCapStyle endCap = D2DCapStyle.Flat)
 		{
 			HANDLE handle = D2D.CreateStrokeStyle(this.Handle, dashes, dashes != null ? (uint)dashes.Length : 0, dashOffset, startCap, endCap);
@@ -54,8 +54,8 @@ namespace unvell.D2DLib
 			return handle == HANDLE.Zero ? null : new D2DStrokeStyle(this, handle, dashes, dashOffset, startCap, endCap);
 		}
 
-		public D2DPen CreatePen(D2DColor color, D2DDashStyle dashStyle = D2DDashStyle.Solid,
-			float[] customDashes = null, float dashOffset = 0.0f)
+		public D2DPen? CreatePen(D2DColor color, D2DDashStyle dashStyle = D2DDashStyle.Solid,
+			float[]? customDashes = null, float dashOffset = 0.0f)
 		{
 			HANDLE handle = D2D.CreatePen(this.Handle, color, dashStyle,
 			customDashes, customDashes != null ? (uint)customDashes.Length : 0, dashOffset);
@@ -69,7 +69,7 @@ namespace unvell.D2DLib
 			D2D.DestroyPen(pen.Handle);
 		}
 
-		public D2DSolidColorBrush CreateSolidColorBrush(D2DColor color)
+		public D2DSolidColorBrush? CreateSolidColorBrush(D2DColor color)
 		{
 			HANDLE handle = D2D.CreateSolidColorBrush(this.Handle, color);
 			return handle == HANDLE.Zero ? null : new D2DSolidColorBrush(handle, color);
@@ -143,29 +143,29 @@ namespace unvell.D2DLib
 			return path;
 		}
 
-		public D2DBitmap LoadBitmap(byte[] buffer)
+		public D2DBitmap? LoadBitmap(byte[] buffer)
 		{
 			return this.LoadBitmap(buffer, 0, (uint)buffer.Length);
 		}
 
-		public D2DBitmap LoadBitmap(byte[] buffer, UINT offset, UINT length)
+		public D2DBitmap? LoadBitmap(byte[] buffer, UINT offset, UINT length)
 		{
 			var bitmapHandle = D2D.CreateBitmapFromBytes(this.Handle, buffer, offset, length);
 			return (bitmapHandle != HWND.Zero) ? new D2DBitmap(bitmapHandle) : null;
 		}
 
-		public D2DBitmap LoadBitmap(string filepath)
+		public D2DBitmap? LoadBitmap(string filepath)
 		{
 			return CreateBitmapFromFile(filepath);
 		}
 
-		public D2DBitmap CreateBitmapFromFile(string filepath)
+		public D2DBitmap? CreateBitmapFromFile(string filepath)
 		{
 			var bitmapHandle = D2D.CreateBitmapFromFile(this.Handle, filepath);
 			return (bitmapHandle != HWND.Zero) ? new D2DBitmap(bitmapHandle) : null;
 		}
 
-		public D2DBitmap CreateBitmapFromMemory(UINT width, UINT height, UINT stride, IntPtr buffer, UINT offset, UINT length)
+		public D2DBitmap? CreateBitmapFromMemory(UINT width, UINT height, UINT stride, IntPtr buffer, UINT offset, UINT length)
 		{
 			HANDLE d2dbmp = D2D.CreateBitmapFromMemory(this.Handle, width, height, stride, buffer, offset, length);
 			return d2dbmp == HANDLE.Zero ? null : new D2DBitmap(d2dbmp);
@@ -179,13 +179,13 @@ namespace unvell.D2DLib
 		[DllImport("gdi32.dll")]
 		public static extern bool DeleteObject(IntPtr obj);
 
-		public D2DBitmap CreateBitmapFromHBitmap(HWND hbmp, bool useAlphaChannel)
+		public D2DBitmap? CreateBitmapFromHBitmap(HWND hbmp, bool useAlphaChannel)
 		{
 			HANDLE d2dbmp = D2D.CreateBitmapFromHBitmap(this.Handle, hbmp, useAlphaChannel);
 			return d2dbmp == HANDLE.Zero ? null : new D2DBitmap(d2dbmp);
 		}
 
-		public D2DBitmap CreateBitmapFromGDIBitmap(System.Drawing.Bitmap bmp)
+		public D2DBitmap? CreateBitmapFromGDIBitmap(System.Drawing.Bitmap bmp)
 		{
 			bool useAlphaChannel =
 				(bmp.PixelFormat & System.Drawing.Imaging.PixelFormat.Alpha) == System.Drawing.Imaging.PixelFormat.Alpha;
@@ -193,7 +193,7 @@ namespace unvell.D2DLib
 			return this.CreateBitmapFromGDIBitmap(bmp, useAlphaChannel);
 		}
 
-		public D2DBitmap CreateBitmapFromGDIBitmap(System.Drawing.Bitmap bmp, bool useAlphaChannel)
+		public D2DBitmap? CreateBitmapFromGDIBitmap(System.Drawing.Bitmap bmp, bool useAlphaChannel)
 		{
 			HANDLE d2dbmp = HANDLE.Zero;
 			HANDLE hbitmap = bmp.GetHbitmap();
@@ -207,17 +207,17 @@ namespace unvell.D2DLib
 			return d2dbmp == HANDLE.Zero ? null : new D2DBitmap(d2dbmp);
 		}
 
-		public D2DBitmapGraphics CreateBitmapGraphics()
+		public D2DBitmapGraphics? CreateBitmapGraphics()
 		{
 			return CreateBitmapGraphics(D2DSize.Empty);
 		}
 
-		public D2DBitmapGraphics CreateBitmapGraphics(float width, float height)
+		public D2DBitmapGraphics? CreateBitmapGraphics(float width, float height)
 		{
 			return CreateBitmapGraphics(new D2DSize(width, height));
 		}
 
-		public D2DBitmapGraphics CreateBitmapGraphics(D2DSize size)
+		public D2DBitmapGraphics? CreateBitmapGraphics(D2DSize size)
 		{
 			HANDLE bitmapRenderTargetHandle = D2D.CreateBitmapRenderTarget(this.Handle, size);
 			return bitmapRenderTargetHandle == HANDLE.Zero ? null

--- a/src/D2DLibExport/D2DDevice.cs
+++ b/src/D2DLibExport/D2DDevice.cs
@@ -22,18 +22,7 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
 
 namespace unvell.D2DLib
 {

--- a/src/D2DLibExport/D2DEnums.cs
+++ b/src/D2DLibExport/D2DEnums.cs
@@ -22,10 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace unvell.D2DLib
 {
 	enum D2DDebugLevel

--- a/src/D2DLibExport/D2DGeometry.cs
+++ b/src/D2DLibExport/D2DGeometry.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
   public class D2DGeometry : D2DObject

--- a/src/D2DLibExport/D2DGraphics.cs
+++ b/src/D2DLibExport/D2DGraphics.cs
@@ -22,18 +22,7 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Runtime.InteropServices;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
 
 namespace unvell.D2DLib
 {

--- a/src/D2DLibExport/D2DGraphics.cs
+++ b/src/D2DLibExport/D2DGraphics.cs
@@ -30,7 +30,7 @@ namespace unvell.D2DLib
 	{
 		internal HANDLE Handle { get; }
 
-		public D2DDevice Device { get; }
+		public D2DDevice? Device { get; }
 
 		public D2DGraphics(D2DDevice context)
 			: this(context.Handle)
@@ -222,7 +222,7 @@ namespace unvell.D2DLib
 			D2D.PopClip(this.Handle);
 		}
 
-		public D2DLayer PushLayer(D2DGeometry geometry = null)
+		public D2DLayer PushLayer(D2DGeometry? geometry = null)
 		{
 			// FIXME: resolve to not use magic number
 			D2DRect rectBounds = new D2DRect(-999999, -999999, 999999999, 999999999);
@@ -230,13 +230,14 @@ namespace unvell.D2DLib
 			return PushLayer(rectBounds, geometry);
 		}
 
-		public D2DLayer PushLayer(D2DRect rectBounds, D2DGeometry geometry = null)
+		public D2DLayer PushLayer(D2DRect rectBounds, D2DGeometry? geometry = null)
 		{
+			Assumes.NotNull(this.Device);
 			var layer = this.Device.CreateLayer();
 			return PushLayer(layer, rectBounds, geometry);
 		}
 
-		public D2DLayer PushLayer(D2DLayer layer, D2DRect rectBounds, D2DGeometry geometry = null, D2DBrush opacityBrush = null)
+		public D2DLayer PushLayer(D2DLayer layer, D2DRect rectBounds, D2DGeometry? geometry = null, D2DBrush? opacityBrush = null)
 		{
 			D2D.PushLayer(this.Handle, layer.Handle, rectBounds, geometry != null ? geometry.Handle : IntPtr.Zero, opacityBrush != null ? opacityBrush.Handle : IntPtr.Zero);
 			return layer;
@@ -464,11 +465,13 @@ namespace unvell.D2DLib
 
 		public void GetDPI(out float dpiX, out float dpiY)
 		{
+			Assumes.NotNull(this.Device);
 			D2D.GetDPI(this.Device.Handle, out dpiX, out dpiY);
 		}
 
 		public void SetDPI(float dpiX, float dpiY)
 		{
+			Assumes.NotNull(this.Device);
 			D2D.SetDPI(this.Device.Handle, dpiX, dpiY);
 		}
 	}

--- a/src/D2DLibExport/D2DLayer.cs
+++ b/src/D2DLibExport/D2DLayer.cs
@@ -1,10 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using HANDLE = System.IntPtr;
-
 namespace unvell.D2DLib
 {
   public class D2DLayer : D2DObject

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -22,20 +22,7 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-using System.Drawing.Drawing2D;
-using System.Drawing;
 
 namespace unvell.D2DLib
 {

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -293,14 +293,14 @@ namespace unvell.D2DLib
 
 		#region Style
 		[DllImport(DLL_NAME, EntryPoint = "CreateStrokeStyle", CallingConvention = CallingConvention.Cdecl)]
-		public static extern HANDLE CreateStrokeStyle(HANDLE ctx, FLOAT[] dashes = null, UINT dashCount = 0, FLOAT dashOffset = 0.0f,
+		public static extern HANDLE CreateStrokeStyle(HANDLE ctx, FLOAT[]? dashes = null, UINT dashCount = 0, FLOAT dashOffset = 0.0f,
 				D2DCapStyle startCap = D2DCapStyle.Flat, D2DCapStyle endCap = D2DCapStyle.Flat);
 		#endregion Style
 
 		#region Pen
 		[DllImport(DLL_NAME, EntryPoint = "CreatePenStroke", CallingConvention = CallingConvention.Cdecl)]
 		public static extern HANDLE CreatePen(HANDLE ctx, D2DColor strokeColor, D2DDashStyle dashStyle = D2DDashStyle.Solid,
-	FLOAT[] dashes = null, UINT dashCount = 0, FLOAT dashOffset = 0.0f);
+	FLOAT[]? dashes = null, UINT dashCount = 0, FLOAT dashOffset = 0.0f);
 
 		[DllImport(DLL_NAME, EntryPoint = "DestroyPenStroke", CallingConvention = CallingConvention.Cdecl)]
 		public static extern void DestroyPen(HANDLE pen);

--- a/src/D2DLibExport/D2DLinearGradientBrush.cs
+++ b/src/D2DLibExport/D2DLinearGradientBrush.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
   public class D2DLinearGradientBrush : D2DBrush

--- a/src/D2DLibExport/D2DObject.cs
+++ b/src/D2DLibExport/D2DObject.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
   public class D2DObject : IDisposable

--- a/src/D2DLibExport/D2DPathGeometry.cs
+++ b/src/D2DLibExport/D2DPathGeometry.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
 	public class D2DPathGeometry : D2DGeometry

--- a/src/D2DLibExport/D2DPen.cs
+++ b/src/D2DLibExport/D2DPen.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
 	public class D2DPen : D2DObject

--- a/src/D2DLibExport/D2DPen.cs
+++ b/src/D2DLibExport/D2DPen.cs
@@ -32,12 +32,12 @@ namespace unvell.D2DLib
 
 		public D2DDashStyle DashStyle { get; private set; }
 
-		public float[] CustomDashes { get; private set; }
+		public float[]? CustomDashes { get; private set; }
 
 		public float DashOffset { get; private set; }
 
 		internal D2DPen(D2DDevice Device, HANDLE handle, D2DColor color, D2DDashStyle dashStyle = D2DDashStyle.Solid,
-			float[] customDashes = null, float dashOffset = 0f)
+			float[]? customDashes = null, float dashOffset = 0f)
 			: base(handle)
 		{
 			this.Device = Device;

--- a/src/D2DLibExport/D2DPieGeometry.cs
+++ b/src/D2DLibExport/D2DPieGeometry.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
 	public class D2DPieGeometry : D2DGeometry

--- a/src/D2DLibExport/D2DRadialGradientBrush.cs
+++ b/src/D2DLibExport/D2DRadialGradientBrush.cs
@@ -22,18 +22,7 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
 
 namespace unvell.D2DLib
 {

--- a/src/D2DLibExport/D2DRectangleGeometry.cs
+++ b/src/D2DLibExport/D2DRectangleGeometry.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
   public class D2DRectangleGeometry : D2DGeometry

--- a/src/D2DLibExport/D2DSolidColorBrush.cs
+++ b/src/D2DLibExport/D2DSolidColorBrush.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
   public class D2DSolidColorBrush : D2DBrush

--- a/src/D2DLibExport/D2DStrokeStyle.cs
+++ b/src/D2DLibExport/D2DStrokeStyle.cs
@@ -28,7 +28,7 @@ namespace unvell.D2DLib
 	{
 		public D2DDevice Device { get; }
 
-		public float[] Dashes { get; }
+		public float[]? Dashes { get; }
 
 		public float DashOffset { get; }
 
@@ -36,7 +36,7 @@ namespace unvell.D2DLib
 
 		public D2DCapStyle EndCap { get; } = D2DCapStyle.Flat;
 
-		internal D2DStrokeStyle(D2DDevice Device, HANDLE handle, float[] dashes, float dashOffset, D2DCapStyle startCap, D2DCapStyle endCap)
+		internal D2DStrokeStyle(D2DDevice Device, HANDLE handle, float[]? dashes, float dashOffset, D2DCapStyle startCap, D2DCapStyle endCap)
 			: base(handle)
 		{
 			this.Device = Device;

--- a/src/D2DLibExport/D2DStrokeStyle.cs
+++ b/src/D2DLibExport/D2DStrokeStyle.cs
@@ -22,19 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using FLOAT = System.Single;
-using UINT = System.UInt32;
-using UINT32 = System.UInt32;
-using HWND = System.IntPtr;
-using HANDLE = System.IntPtr;
-using HRESULT = System.Int64;
-using BOOL = System.Int32;
-
 namespace unvell.D2DLib
 {
 	public class D2DStrokeStyle : D2DObject

--- a/src/D2DLibExport/D2DStructs.cs
+++ b/src/D2DLibExport/D2DStructs.cs
@@ -22,10 +22,7 @@
 * SOFTWARE.
 */
 
-using System;
 using System.Runtime.InteropServices;
-
-using FLOAT = System.Single;
 
 namespace unvell.D2DLib
 {

--- a/src/D2DLibExport/MathFunctions.cs
+++ b/src/D2DLibExport/MathFunctions.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace unvell.D2DLib
 {
 	public class MathFunctions

--- a/src/D2DWinForm/D2DControl.cs
+++ b/src/D2DWinForm/D2DControl.cs
@@ -26,7 +26,7 @@ namespace unvell.D2DLib.WinForm
 {
 	public class D2DControl : System.Windows.Forms.Control
 	{
-		private D2DDevice device;
+		private D2DDevice? device;
 
 		public D2DDevice Device
 		{
@@ -41,7 +41,7 @@ namespace unvell.D2DLib.WinForm
 			}
 		}
 
-		private D2DGraphics graphics;
+		private D2DGraphics? graphics;
 
 		private int currentFps = 0;
 		private int lastFps = 0;
@@ -62,9 +62,9 @@ namespace unvell.D2DLib.WinForm
 			this.graphics = new D2DGraphics(this.device);
 		}
 
-		private D2DBitmap backgroundImage = null;
+		private D2DBitmap? backgroundImage = null;
 
-		public new D2DBitmap BackgroundImage
+		public new D2DBitmap? BackgroundImage
 		{
 			get { return this.backgroundImage; }
 			set
@@ -85,6 +85,8 @@ namespace unvell.D2DLib.WinForm
 
 		protected override void OnPaint(System.Windows.Forms.PaintEventArgs e)
 		{
+			Assumes.NotNull(this.graphics);
+
 			if (this.backgroundImage != null)
 			{
 				this.graphics.BeginRender(this.backgroundImage);
@@ -120,7 +122,7 @@ namespace unvell.D2DLib.WinForm
 		protected override void DestroyHandle()
 		{
 			base.DestroyHandle();
-			this.device.Dispose();
+			this.device?.Dispose();
 		}
 
 		protected virtual void OnRender(D2DGraphics g) { }

--- a/src/D2DWinForm/D2DControl.cs
+++ b/src/D2DWinForm/D2DControl.cs
@@ -22,9 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Windows.Forms;
-
 namespace unvell.D2DLib.WinForm
 {
 	public class D2DControl : System.Windows.Forms.Control

--- a/src/D2DWinForm/D2DWinForm.cs
+++ b/src/D2DWinForm/D2DWinForm.cs
@@ -22,8 +22,7 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Windows.Forms;
+using Timer = System.Windows.Forms.Timer;
 
 namespace unvell.D2DLib.WinForm
 {

--- a/src/D2DWinForm/D2DWinForm.cs
+++ b/src/D2DWinForm/D2DWinForm.cs
@@ -28,7 +28,7 @@ namespace unvell.D2DLib.WinForm
 {
 	public class D2DForm : Form
 	{
-		private D2DDevice device;
+		private D2DDevice? device;
 		public D2DDevice Device
 		{
 			get
@@ -42,9 +42,9 @@ namespace unvell.D2DLib.WinForm
 			}
 		}
 
-		private D2DBitmap backgroundImage = null;
+		private D2DBitmap? backgroundImage = null;
 
-		public new D2DBitmap BackgroundImage
+		public new D2DBitmap? BackgroundImage
 		{
 			get { return this.backgroundImage; }
 			set
@@ -61,7 +61,7 @@ namespace unvell.D2DLib.WinForm
 			}
 		}
 
-		private D2DGraphics graphics;
+		private D2DGraphics? graphics;
 
 		private int currentFps = 0;
 		private int lastFps = 0;
@@ -131,6 +131,8 @@ namespace unvell.D2DLib.WinForm
 			}
 			else
 			{
+				Assumes.NotNull(this.graphics);
+
 				if (this.backgroundImage != null)
 				{
 					this.graphics.BeginRender(this.backgroundImage);

--- a/src/D2DWinForm/D2DWinForm.csproj
+++ b/src/D2DWinForm/D2DWinForm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <Import Project="..\NativeLibraries.props" />
-  
+
   <!-- Build properties -->
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
@@ -25,6 +25,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\D2DLibExport\D2DLibExport.csproj" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Drawing" />
+    <Using Include="System.Windows.Forms" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/D2DWinForm/D2DWinForm.csproj
+++ b/src/D2DWinForm/D2DWinForm.csproj
@@ -24,6 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\D2DLibExport\Assumes.cs" Link="Assumes.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\D2DLibExport\D2DLibExport.csproj" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/D2DWinForm/Extensions.cs
+++ b/src/D2DWinForm/Extensions.cs
@@ -22,14 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-
-using HANDLE = System.IntPtr;
-
 namespace unvell.D2DLib.WinForm
 {
 	public static class D2DWinFormExtensions

--- a/src/D2DWinForm/Win32.cs
+++ b/src/D2DWinForm/Win32.cs
@@ -1175,7 +1175,7 @@ namespace unvell.D2DLib.WinForm
 			public byte lfQuality = 0;
 			public byte lfPitchAndFamily = 0;
 			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 0x20)]
-			public string lfFaceName;
+			public string? lfFaceName;
 		}
 
 		[DllImport("gdi32.dll")]

--- a/src/D2DWinForm/Win32.cs
+++ b/src/D2DWinForm/Win32.cs
@@ -42,12 +42,8 @@
 // Disable variable not used warning
 #pragma warning disable 0649
 
-using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Runtime.InteropServices;
-using System.Drawing;
-using System.Windows.Forms;
 
 namespace unvell.D2DLib.WinForm
 {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Platforms>x86;x64</Platforms>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,22 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Single" Alias="FLOAT" />
+    <Using Include="System.UInt32" Alias="UINT" />
+    <Using Include="System.UInt32" Alias="UINT32" />
+    <Using Include="System.IntPtr" Alias="HWND" />
+    <Using Include="System.IntPtr" Alias="HANDLE" />
+    <Using Include="System.Int64" Alias="HRESULT" />
+    <Using Include="System.Int32" Alias="BOOL" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Required for DeterministicSourcePaths -->
     <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <Platforms>x86;x64</Platforms>
     <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -12,6 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Nullable" Version="1.3.1" Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/D2DHybridForm.cs
+++ b/src/Examples/D2DHybridForm.cs
@@ -22,9 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Drawing;
-using System.Windows.Forms;
 using unvell.D2DLib.WinForm;
 
 namespace unvell.D2DLib.Examples

--- a/src/Examples/DemoSelectionForm.cs
+++ b/src/Examples/DemoSelectionForm.cs
@@ -21,10 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
- 
-using System;
+
 using System.Reflection;
-using System.Windows.Forms;
+
 using unvell.D2DLib.WinForm;
 
 namespace unvell.D2DLib.Examples

--- a/src/Examples/Demos/BitmapCustomDraw.cs
+++ b/src/Examples/Demos/BitmapCustomDraw.cs
@@ -22,11 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Drawing;
-using System.Windows.Forms;
-using unvell.D2DLib.WinForm;
-
 namespace unvell.D2DLib.Examples.Demos
 {
 	public partial class BitmapCustomDraw : DemoForm

--- a/src/Examples/Demos/HitTestByInverseTransform.cs
+++ b/src/Examples/Demos/HitTestByInverseTransform.cs
@@ -22,11 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
-using unvell.D2DLib.WinForm;
 using System.Numerics;
 
 namespace unvell.D2DLib.Examples.Demos

--- a/src/Examples/Demos/ImageTest.cs
+++ b/src/Examples/Demos/ImageTest.cs
@@ -22,10 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Windows.Forms;
-using unvell.D2DLib.WinForm;
-
 namespace unvell.D2DLib.Examples.Demos
 {
 	class ImageTest : DemoForm

--- a/src/Examples/Demos/ManyTextRender.cs
+++ b/src/Examples/Demos/ManyTextRender.cs
@@ -22,11 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
-using unvell.D2DLib;
 using unvell.D2DLib.WinForm;
 
 namespace unvell.D2DLib.Examples.Demos

--- a/src/Examples/Demos/PieChart.cs
+++ b/src/Examples/Demos/PieChart.cs
@@ -22,10 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
 using unvell.D2DLib.WinForm;
 
 namespace unvell.D2DLib.Examples.Demos

--- a/src/Examples/Demos/StarSpace.cs
+++ b/src/Examples/Demos/StarSpace.cs
@@ -22,12 +22,7 @@
 * SOFTWARE.
 */
 
-using System;
 using System.ComponentModel;
-using System.Drawing;
-using System.Windows.Forms;
-
-using unvell.D2DLib.WinForm;
 
 namespace unvell.D2DLib.Examples.Demos
 {

--- a/src/Examples/Demos/Subtitle.cs
+++ b/src/Examples/Demos/Subtitle.cs
@@ -22,8 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Drawing;
 using unvell.D2DLib.WinForm;
 using unvell.D2DLib.Examples.Properties;
 

--- a/src/Examples/Demos/TransparentIconDraw.cs
+++ b/src/Examples/Demos/TransparentIconDraw.cs
@@ -29,7 +29,7 @@ namespace unvell.D2DLib.Examples.Demos
 	{
 		public TransparentMemoryBitmapDraw()
 		{
-			Text = "Transparenct Images Draw - d2dlib Examples";
+			Text = "Transparent Images Draw - d2dlib Examples";
 			WindowState = FormWindowState.Maximized;
 
 			AnimationDraw = true;

--- a/src/Examples/Demos/TransparentIconDraw.cs
+++ b/src/Examples/Demos/TransparentIconDraw.cs
@@ -22,13 +22,6 @@
  * SOFTWARE.
  */
 
- using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
-using unvell.D2DLib.WinForm;
 
 namespace unvell.D2DLib.Examples.Demos
 {

--- a/src/Examples/Demos/Whiteboard.cs
+++ b/src/Examples/Demos/Whiteboard.cs
@@ -22,9 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Drawing;
-using System.Windows.Forms;
 using unvell.D2DLib.WinForm;
 
 namespace unvell.D2DLib.Examples.Demos

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -6,6 +6,7 @@
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -13,4 +13,9 @@
     <ProjectReference Include="..\D2DWinForm\D2DWinForm.csproj" IncludeAssets="contentFiles" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="System.Drawing" />
+    <Using Include="System.Windows.Forms" />
+  </ItemGroup>
+
 </Project>

--- a/src/Examples/MenuForm.cs
+++ b/src/Examples/MenuForm.cs
@@ -22,14 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
-using System.Windows.Forms;
-
 namespace unvell.D2DLib.Examples
 {
 	public partial class MenuForm : Form

--- a/src/Examples/Program.cs
+++ b/src/Examples/Program.cs
@@ -22,10 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Windows.Forms;
-
 namespace unvell.D2DLib.Examples
 {
 	static class Program

--- a/src/Examples/SampleCode/ClipMaskDraw.cs
+++ b/src/Examples/SampleCode/ClipMaskDraw.cs
@@ -22,12 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
-using unvell.D2DLib.WinForm;
-
 namespace unvell.D2DLib.Examples.SampleCode
 {
 	public partial class ClipMaskDraw : ExampleForm

--- a/src/Examples/SampleCode/HelloWorld.cs
+++ b/src/Examples/SampleCode/HelloWorld.cs
@@ -22,12 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
-using unvell.D2DLib.WinForm;
-
 namespace unvell.D2DLib.Examples.SampleCode
 {
 	public partial class HelloWorld : ExampleForm

--- a/src/Examples/SampleCode/LineCapStyle.cs
+++ b/src/Examples/SampleCode/LineCapStyle.cs
@@ -22,12 +22,6 @@
 * SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
-using unvell.D2DLib.WinForm;
-
 namespace unvell.D2DLib.Examples.SampleCode
 {
 	public partial class LineCapStyle : ExampleForm

--- a/src/Examples/SampleCode/MeasureAndDrawStringForm.cs
+++ b/src/Examples/SampleCode/MeasureAndDrawStringForm.cs
@@ -22,11 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Drawing;
-using unvell.D2DLib.WinForm;
-using unvell.D2DLib.Examples.Properties;
-
 namespace unvell.D2DLib.Examples.SampleCode
 {
 	public partial class MeasureAndDrawStringForm : ExampleForm

--- a/src/Examples/SampleCode/TextStyles.cs
+++ b/src/Examples/SampleCode/TextStyles.cs
@@ -22,14 +22,6 @@
  * SOFTWARE.
  */
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Windows.Forms;
-using unvell.D2DLib;
-using unvell.D2DLib.WinForm;
-
 namespace unvell.D2DLib.Examples.SampleCode
 {
 	public partial class TextStyles : ExampleForm


### PR DESCRIPTION
- Fix `.editorconfig` to use tabs consistently in VS
- Specify imports and aliases as MSBuild items to reduce boilerplate in code
- Enable nullable reference types in the core library so that consumers can identify when values are null more easily
- Bump compiler version

Each step is a separate commit, so we can back out individual changes if needed.