### PR TITLE
Use system.numerics instead of customized struct D2DPoint and D2DMatrix3x2

### DIFF
--- a/src/D2DLibExport/D2DDevice.cs
+++ b/src/D2DLibExport/D2DDevice.cs
@@ -126,11 +126,11 @@ namespace unvell.D2DLib
 			var eangle = endAngle * Math.PI / 180f;
 			var angleDiff = endAngle - startAngle;
 
-			var startPoint = new D2DPoint((float)(origin.x + halfSize.width * Math.Cos(sangle)),
-				(float)(origin.y + halfSize.height * Math.Sin(sangle)));
+			var startPoint = new D2DPoint((float)(origin.X + halfSize.width * Math.Cos(sangle)),
+				(float)(origin.Y + halfSize.height * Math.Sin(sangle)));
 
-			var endPoint = new D2DPoint((float)(origin.x + halfSize.width * Math.Cos(eangle)),
-				(float)(origin.y + halfSize.height * Math.Sin(eangle)));
+			var endPoint = new D2DPoint((float)(origin.X + halfSize.width * Math.Cos(eangle)),
+				(float)(origin.Y + halfSize.height * Math.Sin(eangle)));
 
 			path.AddLines(new D2DPoint[] { origin, startPoint });
 

--- a/src/D2DLibExport/D2DGraphics.cs
+++ b/src/D2DLibExport/D2DGraphics.cs
@@ -248,14 +248,14 @@ namespace unvell.D2DLib
 			D2D.PopLayer(this.Handle);
 		}
 
-		public void SetTransform(D2DMatrix3x2 mat)
+		public void SetTransform(Matrix3x2 mat)
 		{
 			D2D.SetTransform(this.Handle, ref mat);
 		}
 
-		public D2DMatrix3x2 GetTransform()
+		public Matrix3x2 GetTransform()
 		{
-			D2DMatrix3x2 mat;
+			Matrix3x2 mat;
 			D2D.GetTransform(this.Handle, out mat);
 			return mat;
 		}

--- a/src/D2DLibExport/D2DGraphics.cs
+++ b/src/D2DLibExport/D2DGraphics.cs
@@ -108,8 +108,8 @@ namespace unvell.D2DLib
 			FLOAT weight = 1, D2DDashStyle dashStyle = D2DDashStyle.Solid)
 		{
 			var ellipse = new D2DEllipse(x, y, width / 2f, height / 2f);
-			ellipse.origin.x += ellipse.radiusX;
-			ellipse.origin.y += ellipse.radiusY;
+			ellipse.origin.X += ellipse.radiusX;
+			ellipse.origin.Y += ellipse.radiusY;
 
 			this.DrawEllipse(ellipse, color, weight, dashStyle);
 		}
@@ -142,8 +142,8 @@ namespace unvell.D2DLib
 		public void FillEllipse(D2DPoint p, FLOAT w, FLOAT h, D2DColor color)
 		{
 			D2DEllipse ellipse = new D2DEllipse(p, w / 2, h / 2);
-			ellipse.origin.x += ellipse.radiusX;
-			ellipse.origin.y += ellipse.radiusY;
+			ellipse.origin.X += ellipse.radiusX;
+			ellipse.origin.Y += ellipse.radiusY;
 
 			this.FillEllipse(ellipse, color);
 		}
@@ -443,7 +443,7 @@ namespace unvell.D2DLib
 			D2DFontStyle fontStyle = D2DFontStyle.Normal,
 			D2DFontStretch fontStretch = D2DFontStretch.Normal)
 		{
-			this.DrawStrokedText(text, location.x, location.y, strokeColor, strokeWidth, fillColor,
+			this.DrawStrokedText(text, location.X, location.Y, strokeColor, strokeWidth, fillColor,
 				fontName, fontSize, fontWeight, fontStyle, fontStretch);
 		}
 

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -123,9 +123,9 @@ namespace unvell.D2DLib
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void SkewTransform([In] HANDLE ctx, [In] FLOAT angleX, [In] FLOAT angleY, [Optional] D2DPoint center);
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void SetTransform([In] HANDLE context, [In] ref D2DMatrix3x2 mat);
+		public static extern void SetTransform([In] HANDLE context, [In] ref Matrix3x2 mat);
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void GetTransform([In] HANDLE context, [Out] out D2DMatrix3x2 mat);
+		public static extern void GetTransform([In] HANDLE context, [Out] out Matrix3x2 mat);
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void ResetTransform([In] HANDLE context);
 
@@ -300,7 +300,7 @@ namespace unvell.D2DLib
 		public static extern void GetGeometryBounds(HANDLE pathCtx, ref D2DRect rect);
 
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void GetGeometryTransformedBounds(HANDLE pathCtx, ref D2DMatrix3x2 mat3x2, ref D2DRect rect);
+		public static extern void GetGeometryTransformedBounds(HANDLE pathCtx, ref Matrix3x2 mat3x2, ref D2DRect rect);
 
 		#endregion // Geometry
 

--- a/src/D2DLibExport/D2DLibExport.csproj
+++ b/src/D2DLibExport/D2DLibExport.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="4.7.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" PrivateAssets="all" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/D2DLibExport/D2DPathGeometry.cs
+++ b/src/D2DLibExport/D2DPathGeometry.cs
@@ -58,8 +58,8 @@ namespace unvell.D2DLib
 		//}
 
 		public void AddArc(D2DPoint endPoint, D2DSize size, FLOAT sweepAngle,
-				D2DArcSize arcSize = D2DArcSize.Small,
-				D2DSweepDirection sweepDirection = D2DSweepDirection.Clockwise)
+			D2DArcSize arcSize = D2DArcSize.Small,
+			D2DSweepDirection sweepDirection = D2DSweepDirection.Clockwise)
 		{
 			D2D.AddPathArc(this.Handle, endPoint, size, sweepAngle, arcSize, sweepDirection);
 		}

--- a/src/D2DLibExport/D2DStructs.cs
+++ b/src/D2DLibExport/D2DStructs.cs
@@ -323,6 +323,16 @@ namespace unvell.D2DLib
 
 		public static readonly D2DSize Empty = new D2DSize(0, 0);
 
+		public static implicit operator D2DSize(Vector2 v)
+		{
+			return new D2DSize(v.X, v.Y);
+		}
+
+		public static implicit operator Vector2(D2DSize v)
+		{
+			return new Vector2(v.width, v.height);
+		}
+
 		public static implicit operator D2DSize(System.Drawing.Size wsize)
 		{
 			return new D2DSize(wsize.Width, wsize.Height);

--- a/src/D2DLibExport/D2DStructs.cs
+++ b/src/D2DLibExport/D2DStructs.cs
@@ -405,24 +405,6 @@ namespace unvell.D2DLib
 			this.point3 = new D2DPoint(x3, y3);
 		}
 	}
-	#endregion
+	#endregion // BezierSegment
 
-	#region Matrix
-	[Serializable]
-	[StructLayout(LayoutKind.Sequential)]
-	public struct D2DMatrix3x2
-	{
-		public FLOAT a1, b1;
-		public FLOAT a2, b2;
-		public FLOAT a3, b3;
-
-		public D2DMatrix3x2(float a1, float b1, float a2, float b2, float a3, float b3)
-		{
-			this.a1 = a1; this.b1 = b1;
-			this.a2 = a2; this.b2 = b2;
-			this.a3 = a3; this.b3 = b3;
-		}
-	}
-
-	#endregion // Matrix
 }

--- a/src/D2DLibExport/D2DStructs.cs
+++ b/src/D2DLibExport/D2DStructs.cs
@@ -180,7 +180,7 @@ namespace unvell.D2DLib
 		public static readonly D2DColor HotPink = D2DColor.FromGDIColor(System.Drawing.Color.HotPink);
 		public static readonly D2DColor LightPink = D2DColor.FromGDIColor(System.Drawing.Color.LightPink);
 	}
-	#endregion
+	#endregion // D2DColor
 
 	#region Rect
 	[Serializable]
@@ -201,8 +201,9 @@ namespace unvell.D2DLib
 		}
 
 		public D2DRect(D2DPoint origin, D2DSize size)
-			: this(origin.x - size.width * 0.5f, origin.y - size.height * 0.5f, size.width, size.height)
-		{ }
+			: this(origin.X - size.width * 0.5f, origin.Y - size.height * 0.5f, size.width, size.height)
+		{
+		}
 
 		public D2DPoint Location
 		{
@@ -293,7 +294,7 @@ namespace unvell.D2DLib
 			return System.Drawing.Rectangle.Round(rect);
 		}
 	}
-	#endregion Rect
+	#endregion // Rect
 
 	#region Rounded Rect
 

--- a/src/D2DLibExport/D2DStructs.cs
+++ b/src/D2DLibExport/D2DStructs.cs
@@ -211,10 +211,10 @@ namespace unvell.D2DLib
 			{
 				FLOAT width = this.right - this.left;
 				FLOAT height = this.bottom - this.top;
-				this.left = value.x;
-				this.right = value.x + width;
-				this.top = value.y;
-				this.bottom = value.y + height;
+				this.left = value.X;
+				this.right = value.X + width;
+				this.top = value.Y;
+				this.bottom = value.Y + height;
 			}
 		}
 
@@ -307,75 +307,6 @@ namespace unvell.D2DLib
 	}
 	#endregion Rounded Rect
 
-	#region Point
-	[Serializable]
-	[StructLayout(LayoutKind.Sequential)]
-	public struct D2DPoint
-	{
-		public FLOAT x;
-		public FLOAT y;
-
-		public D2DPoint(FLOAT x, FLOAT y)
-		{
-			this.x = x;
-			this.y = y;
-		}
-
-		public void Offset(FLOAT offx, FLOAT offy)
-		{
-			this.x += offx;
-			this.y += offy;
-		}
-
-		public static readonly D2DPoint Zero = new D2DPoint(0, 0);
-		public static readonly D2DPoint One = new D2DPoint(1, 1);
-
-		public override bool Equals(object obj)
-		{
-			if (!(obj is D2DPoint)) return false;
-
-			var p2 = (D2DPoint)obj;
-
-			return x == p2.x && y == p2.y;
-		}
-
-		public static bool operator ==(D2DPoint p1, D2DPoint p2)
-		{
-			return p1.x == p2.x && p1.y == p2.y;
-		}
-
-		public static bool operator !=(D2DPoint p1, D2DPoint p2)
-		{
-			return p1.x != p2.x || p1.y != p2.y;
-		}
-
-		public static implicit operator D2DPoint(System.Drawing.Point p)
-		{
-			return new D2DPoint(p.X, p.Y);
-		}
-
-		public static implicit operator D2DPoint(System.Drawing.PointF p)
-		{
-			return new D2DPoint(p.X, p.Y);
-		}
-
-		public static implicit operator System.Drawing.PointF(D2DPoint p)
-		{
-			return new System.Drawing.PointF(p.x, p.y);
-		}
-
-		public static explicit operator System.Drawing.Point(D2DPoint p)
-		{
-			return System.Drawing.Point.Round(p);
-		}
-
-		public override int GetHashCode()
-		{
-			return (int)((this.x * 0xff) + this.y);
-		}
-	}
-	#endregion
-
 	#region Size
 	[Serializable]
 	[StructLayout(LayoutKind.Sequential)]
@@ -446,8 +377,8 @@ namespace unvell.D2DLib
 		{
 		}
 
-		public FLOAT X { get { return origin.x; } set { origin.x = value; } }
-		public FLOAT Y { get { return origin.y; } set { origin.y = value; } }
+		public FLOAT X { get { return origin.X; } set { origin.X = value; } }
+		public FLOAT Y { get { return origin.Y; } set { origin.Y = value; } }
 	}
 	#endregion
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,6 +33,8 @@
     <Using Include="System.IntPtr" Alias="HANDLE" />
     <Using Include="System.Int64" Alias="HRESULT" />
     <Using Include="System.Int32" Alias="BOOL" />
+    <Using Include="System.Numerics" />
+    <using Include="System.Numerics.Vector2" Alias="D2DPoint" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/Demos/HitTestByInverseTransform.cs
+++ b/src/Examples/Demos/HitTestByInverseTransform.cs
@@ -64,7 +64,7 @@ namespace unvell.D2DLib.Examples.Demos
 			base.OnRender(g);
 
 			// set the transform before draw rect
-			g.SetTransform(mat.toD2DMatrix3x2());
+			g.SetTransform(mat);
 
 			g.FillRectangle(rect, isHitted ? D2DColor.LightYellow : D2DColor.LightGray);
 			g.DrawRectangle(rect, isHitted ? D2DColor.Red : D2DColor.Blue, 2);
@@ -165,22 +165,5 @@ namespace unvell.D2DLib.Examples.Demos
 			return new D2DRect(r.X, r.Y, r.Width, r.Height);
 		}
 	}
-	#endregion /* Rect2D */
-
-	public static class NumericExtension
-	{
-		public static D2DMatrix3x2 toD2DMatrix3x2(this Matrix3x2 mat)
-		{
-			D2DMatrix3x2 d2dmat;
-
-			d2dmat.a1 = mat.M11;
-			d2dmat.b1 = mat.M12;
-			d2dmat.a2 = mat.M21;
-			d2dmat.b2 = mat.M22;
-			d2dmat.a3 = mat.M31;
-			d2dmat.b3 = mat.M32;
-
-			return d2dmat;
-		}
-	}
+	#endregion // Rect2D
 }

--- a/src/Examples/Demos/Whiteboard.cs
+++ b/src/Examples/Demos/Whiteboard.cs
@@ -101,7 +101,7 @@ namespace unvell.D2DLib.Examples.Demos
 		}
 
 		private D2DBitmapGraphics memg;
-		private Point lastPoint, cursorPoint;
+		private Vector2 lastPoint, cursorPoint;
 		private bool isDrawing;
 		private Size penSize = new Size(5, 5);
 		private D2DColor penColor = D2DColor.Blue;  // use white as eraser, other else as normal pen
@@ -143,9 +143,9 @@ namespace unvell.D2DLib.Examples.Demos
 			}
 
 			this.isDrawing = true;
-			this.lastPoint = e.Location;
-			this.cursorPoint = e.Location;
-			drawPen(e.Location);
+			this.lastPoint = new Vector2(e.X, e.Y);
+			this.cursorPoint = new Vector2(e.X, e.Y);
+			drawPen(new Vector2(e.Location.X, e.Location.Y));
 			this.showGettingStart = false;
 
 			// when we're in the eraser, we want to invalidate since the eraser is animated
@@ -156,14 +156,14 @@ namespace unvell.D2DLib.Examples.Demos
 
 		protected override void OnMouseMove(MouseEventArgs e)
 		{
-			this.cursorPoint = e.Location;
+			this.cursorPoint = new Vector2(e.X, e.Y);
 			if (this.isDrawing)
 			{
-				drawPen(e.Location);
+				drawPen(new Vector2(e.Location.X, e.Location.Y));
 			}
 			else
 			{
-				cursorPoint = e.Location;
+				cursorPoint = new Vector2(e.X, e.Y);
 			}
 			this.Invalidate();
 		}
@@ -171,7 +171,7 @@ namespace unvell.D2DLib.Examples.Demos
 		protected override void OnMouseUp(MouseEventArgs e)
 		{
 			this.isDrawing = false;
-			this.cursorPoint = e.Location;
+			this.cursorPoint = new Vector2(e.X, e.Y);
 		}
 
 		protected override void OnMouseEnter(EventArgs e)
@@ -202,9 +202,9 @@ namespace unvell.D2DLib.Examples.Demos
 			this.Invalidate();
 		}
 
-		private void drawPen(Point currentPoint)
+		private void drawPen(Vector2 currentPoint)
 		{
-			var diff = new Point(currentPoint.X - this.lastPoint.X, currentPoint.Y - this.lastPoint.Y);
+			var diff = new Vector2(currentPoint.X - this.lastPoint.X, currentPoint.Y - this.lastPoint.Y);
 
 			memg.BeginRender();
 			D2DEllipse ellipse = new D2DEllipse(D2DPoint.Zero, this.penSize);
@@ -236,10 +236,11 @@ namespace unvell.D2DLib.Examples.Demos
 			this.lastPoint = currentPoint;
 		}
 
-
 		private readonly float[] eraserPenDashes = new[] { 2f, 2f };
+
 		private float eraserDashOffset = 0.0f;
-		private void drawCursor(D2DGraphics g, Point p)
+
+		private void drawCursor(D2DGraphics g, Vector2 p)
 		{
 			if (this.penColor == D2DColor.White)
 			{

--- a/src/Examples/Demos/Whiteboard.cs
+++ b/src/Examples/Demos/Whiteboard.cs
@@ -101,7 +101,7 @@ namespace unvell.D2DLib.Examples.Demos
 		}
 
 		private D2DBitmapGraphics memg;
-		private Vector2 lastPoint, cursorPoint;
+		private Point lastPoint, cursorPoint;
 		private bool isDrawing;
 		private Size penSize = new Size(5, 5);
 		private D2DColor penColor = D2DColor.Blue;  // use white as eraser, other else as normal pen
@@ -143,9 +143,9 @@ namespace unvell.D2DLib.Examples.Demos
 			}
 
 			this.isDrawing = true;
-			this.lastPoint = new Vector2(e.X, e.Y);
-			this.cursorPoint = new Vector2(e.X, e.Y);
-			drawPen(new Vector2(e.Location.X, e.Location.Y));
+			this.lastPoint = e.Location;
+			this.cursorPoint = e.Location;
+			drawPen(e.Location);
 			this.showGettingStart = false;
 
 			// when we're in the eraser, we want to invalidate since the eraser is animated
@@ -156,14 +156,14 @@ namespace unvell.D2DLib.Examples.Demos
 
 		protected override void OnMouseMove(MouseEventArgs e)
 		{
-			this.cursorPoint = new Vector2(e.X, e.Y);
+			this.cursorPoint = e.Location;
 			if (this.isDrawing)
 			{
-				drawPen(new Vector2(e.Location.X, e.Location.Y));
+				drawPen(e.Location);
 			}
 			else
 			{
-				cursorPoint = new Vector2(e.X, e.Y);
+				cursorPoint = e.Location;
 			}
 			this.Invalidate();
 		}
@@ -171,7 +171,7 @@ namespace unvell.D2DLib.Examples.Demos
 		protected override void OnMouseUp(MouseEventArgs e)
 		{
 			this.isDrawing = false;
-			this.cursorPoint = new Vector2(e.X, e.Y);
+			this.cursorPoint = e.Location;
 		}
 
 		protected override void OnMouseEnter(EventArgs e)
@@ -202,7 +202,7 @@ namespace unvell.D2DLib.Examples.Demos
 			this.Invalidate();
 		}
 
-		private void drawPen(Vector2 currentPoint)
+		private void drawPen(Point currentPoint)
 		{
 			var diff = new Vector2(currentPoint.X - this.lastPoint.X, currentPoint.Y - this.lastPoint.Y);
 
@@ -240,7 +240,7 @@ namespace unvell.D2DLib.Examples.Demos
 
 		private float eraserDashOffset = 0.0f;
 
-		private void drawCursor(D2DGraphics g, Vector2 p)
+		private void drawCursor(D2DGraphics g, Point p)
 		{
 			if (this.penColor == D2DColor.White)
 			{
@@ -257,7 +257,7 @@ namespace unvell.D2DLib.Examples.Demos
 			else
 			{
 				// else draw pen
-				g.DrawEllipse(p, this.penSize, this.penColor, 2.0f);
+				g.DrawEllipse(new Vector2(p.X, p.Y), this.penSize, this.penColor, 2.0f);
 			}
 		}
 	}


### PR DESCRIPTION
# Changes

- Use `System.Numerics.Vector2` instead of `D2DPoint`
- Use `System.Numerics.Matrix3x2` instead of `D2DMatrix3x2`
- Make implicit conversion between `D2DSize` and `Vector2`