### PR TITLE
Allow combining geometries

### DIFF
--- a/src/D2DLibExport/D2DDevice.cs
+++ b/src/D2DLibExport/D2DDevice.cs
@@ -110,6 +110,13 @@ namespace unvell.D2DLib
 			return new D2DPathGeometry(this, geoHandle);
 		}
 
+		public D2DPathGeometry CreateCombinedGeometry(D2DPathGeometry path1, D2DPathGeometry path2, 
+			D2D1_COMBINE_MODE combineMode, FLOAT flatteningTolerance = 10f)
+		{
+			HANDLE geoHandle = D2D.CreateCombinedGeometry(this.Handle, path1.Handle, path2.Handle, combineMode, flatteningTolerance);
+			return new D2DPathGeometry(this, geoHandle);
+		}
+
 		public D2DGeometry CreateEllipseGeometry(D2DPoint origin, D2DSize size)
 		{
 			var ellipse = new D2DEllipse(origin, size);

--- a/src/D2DLibExport/D2DEnums.cs
+++ b/src/D2DLibExport/D2DEnums.cs
@@ -601,5 +601,36 @@ namespace unvell.D2DLib
 		/// </summary>
 		UltraExpanded = 9
 	};
+
+	/// <summary>
+	/// This enumeration describes the type of combine operation to be performed.
+	/// </summary>
+	public enum D2D1_COMBINE_MODE
+	{
+
+		/// <summary>
+		/// Produce a geometry representing the set of points contained in either the first
+		/// or the second geometry.
+		/// </summary>
+		D2D1_COMBINE_MODE_UNION = 0,
+
+		/// <summary>
+		/// Produce a geometry representing the set of points common to the first and the
+		/// second geometries.
+		/// </summary>
+		D2D1_COMBINE_MODE_INTERSECT = 1,
+
+		/// <summary>
+		/// Produce a geometry representing the set of points contained in the first
+		/// geometry or the second geometry, but not both.
+		/// </summary>
+		D2D1_COMBINE_MODE_XOR = 2,
+
+		/// <summary>
+		/// Produce a geometry representing the set of points contained in the first
+		/// geometry but not the second geometry.
+		/// </summary>
+		D2D1_COMBINE_MODE_EXCLUDE = 3,
+	}
 }
 

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -26,15 +26,6 @@ using System.Runtime.InteropServices;
 
 namespace unvell.D2DLib
 {
-	public enum D2D1_COMBINE_MODE
-	{
-		D2D1_COMBINE_MODE_UNION = 0,
-		D2D1_COMBINE_MODE_INTERSECT = 1,
-		D2D1_COMBINE_MODE_XOR = 2,
-		D2D1_COMBINE_MODE_EXCLUDE = 3,
-		D2D1_COMBINE_MODE_FORCE_DWORD = -1
-	};
-
 	internal static class D2D
 	{
 

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -26,6 +26,15 @@ using System.Runtime.InteropServices;
 
 namespace unvell.D2DLib
 {
+	public enum D2D1_COMBINE_MODE
+	{
+		D2D1_COMBINE_MODE_UNION = 0,
+		D2D1_COMBINE_MODE_INTERSECT = 1,
+		D2D1_COMBINE_MODE_XOR = 2,
+		D2D1_COMBINE_MODE_EXCLUDE = 3,
+		D2D1_COMBINE_MODE_FORCE_DWORD = -1
+	};
+
 	internal static class D2D
 	{
 
@@ -229,6 +238,10 @@ namespace unvell.D2DLib
 
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern HANDLE CreatePathGeometry(HANDLE ctx);
+
+		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
+		public static extern HANDLE CreateCombinedGeometry(HANDLE d2dCtx, HANDLE pathCtx1, HANDLE pathCtx2,
+			D2D1_COMBINE_MODE combineMode, FLOAT flatteningTolerance = 10f);
 
 		[DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void DestroyPathGeometry(HANDLE ctx);

--- a/src/Examples/SampleCode/GeometriesCombine.cs
+++ b/src/Examples/SampleCode/GeometriesCombine.cs
@@ -1,0 +1,141 @@
+﻿
+
+using System.Drawing;
+using System.IO;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using unvell.D2DLib.Examples.Demos;
+using unvell.D2DLib.WinForm;
+
+namespace unvell.D2DLib.Examples.SampleCode
+{
+	internal class GeometriesCombine : ExampleForm
+	{
+		private const FLOAT left = 250;
+		private const FLOAT offset = 50f;
+		private const FLOAT size = 100f;
+		
+		private const string fontName = "Arials";
+		private const FLOAT fontSize = 20;
+
+		public GeometriesCombine()
+		{
+			Text = "Demonstrate combining two geometries - d2dlib Examples";
+		}
+
+		protected override void OnRender(D2DGraphics g)
+		{
+			/// prepare 
+			D2DColor borderColor = D2DColor.DarkGray;
+			D2DColor fillColor = D2DColor.CornflowerBlue;
+			fillColor.a = 0.25f;
+
+			D2D1_COMBINE_MODE[] modes = {
+				D2D1_COMBINE_MODE.D2D1_COMBINE_MODE_UNION,
+				D2D1_COMBINE_MODE.D2D1_COMBINE_MODE_INTERSECT,
+				D2D1_COMBINE_MODE.D2D1_COMBINE_MODE_XOR,
+				D2D1_COMBINE_MODE.D2D1_COMBINE_MODE_EXCLUDE  
+			};
+
+			string[] modeNames = { "Union", "Intersect", "XOR", "Exclude" };
+
+			/// create test geometries
+			D2DPathGeometry geoSquare = CreateGeometry(false, new D2DRect(left + offset, offset, size, size));
+			D2DPathGeometry geoDiamond = CreateGeometry(true, new D2DRect(left + offset + size / 2, offset, size, size));
+
+			/// start drawing
+			g.Clear(D2DColor.White);
+
+			// draw test geometries without combining them
+			D2DPoint pt = new D2DPoint(0, 0);
+			DrawGeometries(geoSquare, geoDiamond, g, pt, fillColor, borderColor, 2);
+
+			pt.Y += (size + offset / 2);
+
+			// draw test geometries by combining them
+			for (int i = 0; i < modes.Length; i++)
+			{
+				DrawCombinedGeometries(geoSquare, geoDiamond, modes[i], modeNames[i],
+					g, pt, fillColor, borderColor, 2);
+
+				pt.Y += (size + offset / 2);
+			}
+
+		}
+
+		/// <summary>
+		/// Draw the geometry combining G1 and G2 geometries using combineMode 
+		/// </summary>
+		protected void DrawCombinedGeometries(D2DPathGeometry G1, D2DPathGeometry G2, 
+			D2D1_COMBINE_MODE combineMode, string modeName, D2DGraphics g, D2DPoint topLeft,
+			D2DColor fillColor, D2DColor borderColor, float borderWidth)
+		{
+			using (var path = Device.CreateCombinedGeometry(G1, G2, combineMode))
+			{
+				g.PushTransform();
+				g.TranslateTransform(topLeft.X, topLeft.Y);
+
+				g.DrawText(modeName, D2DColor.DimGray, fontName, fontSize, offset, offset + size / 2 - fontSize / 2);
+
+				g.FillPath(path, fillColor);
+				g.DrawPath(path, borderColor, borderWidth);
+
+				g.PopTransform();
+			}
+		}
+
+		/// <summary>
+		/// Draw G1 and G2 geometries without combining them
+		/// </summary>
+		protected void DrawGeometries(D2DPathGeometry G1, D2DPathGeometry G2,
+			D2DGraphics g, D2DPoint topLeft, D2DColor fillColor, D2DColor borderColor, float borderWidth)
+		{
+			g.PushTransform();
+			g.TranslateTransform(topLeft.X, topLeft.Y);
+
+			g.DrawText("Before combining", D2DColor.DimGray, fontName, fontSize, offset, offset + size / 2 - fontSize / 2);
+
+			g.FillPath(G1, fillColor);
+			g.DrawPath(G1, borderColor, borderWidth);
+
+			g.FillPath(G2, fillColor);
+			g.DrawPath(G2, borderColor, borderWidth);
+
+			g.PopTransform();
+		}
+
+		/// <summary>
+		/// Create and return a geometry representing a square or a diamond shape 
+		/// inside the given rect
+		/// </summary>
+		protected D2DPathGeometry CreateGeometry(bool diamond, D2DRect rect)
+		{
+			Vector2 ptStart;
+			Vector2[] points = new Vector2[3];
+
+			if (diamond)
+			{
+				ptStart = new Vector2(rect.left, rect.top + rect.Height / 2);
+				points[0] = new Vector2(rect.left + rect.Width / 2, rect.top);
+				points[1] = new Vector2(rect.right, rect.top + rect.Height / 2);
+				points[2] = new Vector2(rect.left + rect.Width / 2, rect.bottom);
+			}
+			else
+			{
+				ptStart = new Vector2(rect.left, rect.top);
+				points[0] = new Vector2(rect.right, rect.top);
+				points[1] = new Vector2(rect.right, rect.bottom);
+				points[2] = new Vector2(rect.left, rect.bottom);
+			}
+
+			D2DPathGeometry geo = Device.CreatePathGeometry();
+			geo.SetStartPoint(ptStart);
+			geo.AddLines(points);
+			geo.ClosePath();
+
+			return geo;
+		}
+
+
+	}
+}

--- a/src/d2dlib/Geometry.cpp
+++ b/src/d2dlib/Geometry.cpp
@@ -89,6 +89,21 @@ void DestroyPathGeometry(HANDLE ctx)
 	delete pathContext;
 }
 
+D2DLIB_API HANDLE CreateCombinedGeometry(HANDLE d2dCtx, HANDLE pathCtx1, HANDLE pathCtx2, 
+	D2D1_COMBINE_MODE combineMode, FLOAT flatteningTolerance)
+{
+	D2DContext* d2dContext = reinterpret_cast<D2DContext*>(d2dCtx);
+	D2DPathContext* pResultPath = reinterpret_cast<D2DPathContext*>(CreatePathGeometry(d2dContext));
+
+	D2DPathContext* pGeo1Path = reinterpret_cast<D2DPathContext*>(pathCtx1);
+	D2DPathContext* pGeo2Path = reinterpret_cast<D2DPathContext*>(pathCtx2);
+
+	HRESULT hr = pGeo1Path->geometry->CombineWithGeometry(pGeo2Path->geometry, combineMode, NULL, pResultPath->sink);
+	pResultPath->sink->Close();
+
+	return (HANDLE)pResultPath;
+}
+
 void SetPathStartPoint(HANDLE ctx, D2D1_POINT_2F startPoint) {
 	D2DPathContext* pathContext = reinterpret_cast<D2DPathContext*>(ctx);
 

--- a/src/d2dlib/Geometry.h
+++ b/src/d2dlib/Geometry.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * MIT License
 *
 * Copyright (c) 2009-2021 Jingwood, unvell.com. All right reserved.
@@ -36,6 +36,9 @@ extern "C"
 
 	D2DLIB_API HANDLE CreatePathGeometry(HANDLE ctx);
 	D2DLIB_API void DestroyPathGeometry(HANDLE handle);
+
+	D2DLIB_API HANDLE CreateCombinedGeometry(HANDLE d2dCtx, HANDLE pathCtx1, HANDLE pathCtx2,
+		D2D1_COMBINE_MODE combineMode, FLOAT flatteningTolerance = 10.f);
 
 	D2DLIB_API void SetPathStartPoint(HANDLE handle, D2D1_POINT_2F startPoint);
 	D2DLIB_API void ClosePath(HANDLE handle);


### PR DESCRIPTION
Hi,

The proposals in this PR are functionnal. D2DDevice provides the following new method for [combining two path geometries](https://learn.microsoft.com/en-us/windows/win32/direct2d/id2d1geometry-combinewithgeometry). The new GeometriesCombine sample demonstrates it.

Enjoy !

```c#
public D2DPathGeometry CreateCombinedGeometry(D2DPathGeometry path1, D2DPathGeometry path2, 
			D2D1_COMBINE_MODE combineMode, FLOAT flatteningTolerance = 10f)
```
