### PR TITLE
Some minor improvements for PR108

### DIFF
--- a/src/D2DLibExport/D2DDevice.cs
+++ b/src/D2DLibExport/D2DDevice.cs
@@ -115,7 +115,7 @@ namespace unvell.D2DLib
 			return new D2DPathGeometry(this, geoHandle);
 		}
 
-		public D2DPathGeometry CreateCombinedGeometry(D2DPathGeometry path1, D2DPathGeometry path2, 
+		public D2DPathGeometry CreateCombinedGeometry(D2DPathGeometry path1, D2DPathGeometry path2,
 			D2D1CombineMode combineMode, FLOAT flatteningTolerance = 10f)
 		{
 			HANDLE geoHandle = D2D.CreateCombinedGeometry(this.Handle, path1.Handle, path2.Handle, combineMode, flatteningTolerance);
@@ -161,7 +161,7 @@ namespace unvell.D2DLib
 
 			return path;
 		}
-		
+
 		public D2DPathGeometry CreateTextPathGeometry(string text, string fontName, float fontSize,
 			D2DFontWeight fontWeight = D2DFontWeight.Normal,
 			D2DFontStyle fontStyle = D2DFontStyle.Normal,
@@ -184,24 +184,24 @@ namespace unvell.D2DLib
 
 			return new D2DPathGeometry(this, pathHandler);
 		}
-		
-		public D2DFontFormat CreateFontFormat(string fontName, float fontSize, 
-				D2DFontWeight fontWeight = D2DFontWeight.Normal, 
-				D2DFontStyle fontStyle = D2DFontStyle.Normal, 
-				D2DFontStretch fontStretch = D2DFontStretch.Normal, 
+
+		public D2DFontFormat CreateFontFormat(string fontName, float fontSize,
+				D2DFontWeight fontWeight = D2DFontWeight.Normal,
+				D2DFontStyle fontStyle = D2DFontStyle.Normal,
+				D2DFontStretch fontStretch = D2DFontStretch.Normal,
 				DWriteTextAlignment halign = DWriteTextAlignment.Leading,
 				DWriteParagraphAlignment valign = DWriteParagraphAlignment.Near)
-        {
+		{
 			HANDLE fmtHandle = D2D.CreateFontFormat(this.Handle, fontName, fontSize, fontWeight, fontStyle, fontStretch, halign, valign);
 			return new D2DFontFormat(fmtHandle);
 		}
 
 		public D2DTextLayout CreateTextLayout(string text, D2DFontFormat fontFormat, D2DSize size)
-        {
+		{
 			HANDLE fmtHandle = D2D.CreateTextLayout(this.Handle, text, fontFormat.Handle, ref size);
 			return new D2DTextLayout(fmtHandle);
 		}
-		
+
 		public D2DBitmap? LoadBitmap(byte[] buffer)
 		{
 			return this.LoadBitmap(buffer, 0, (uint)buffer.Length);

--- a/src/D2DLibExport/D2DLib.cs
+++ b/src/D2DLibExport/D2DLib.cs
@@ -209,7 +209,7 @@ namespace unvell.D2DLib
 			[In] DWriteTextAlignment halign = DWriteTextAlignment.Leading,
 			[In] DWriteParagraphAlignment valign = DWriteParagraphAlignment.Near);
 
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static extern void MeasureTextWithFormat([In] HANDLE ctx, [In] string text, [In] HANDLE textFormat, ref D2DSize size);
 
@@ -229,7 +229,7 @@ namespace unvell.D2DLib
 		public static extern HANDLE CreateTextPathGeometry(HANDLE ctx, [In] string text,
 			HANDLE fontFaceHandle, FLOAT fontSize);
 
-		[DllImport(DLL_NAME, EntryPoint = "CreateTextFormat", CharSet = CharSet.Unicode)]
+		[DllImport(DLL_NAME, EntryPoint = "CreateTextFormat", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
 		public static extern HANDLE CreateFontFormat([In] HANDLE ctx, [In] string fontName, [In] FLOAT fontSize, 
 			[In] D2DFontWeight fontWeight = D2DFontWeight.Normal, 
 			[In] D2DFontStyle fontStyle = D2DFontStyle.Normal, 
@@ -246,7 +246,7 @@ namespace unvell.D2DLib
 			[In] D2DFontStyle fontStyle = D2DFontStyle.Normal,
 			[In] D2DFontStretch fontStretch = D2DFontStretch.Normal);
 
-		[DllImport(DLL_NAME, CharSet = CharSet.Unicode)]
+		[DllImport(DLL_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static extern void DrawStringWithFormat([In] HANDLE context, [In] string text, [In] HANDLE brush,
 			[In] HANDLE textFormat, [In] ref D2DRect rect);

--- a/src/D2DWinForm/D2DControl.cs
+++ b/src/D2DWinForm/D2DControl.cs
@@ -26,6 +26,8 @@ namespace unvell.D2DLib.WinForm
 {
 	public class D2DControl : System.Windows.Forms.Control
 	{
+		protected FpsCounter fpsCounter = new FpsCounter();
+
 		private D2DDevice? device;
 
 		public D2DDevice Device
@@ -119,7 +121,7 @@ namespace unvell.D2DLib.WinForm
 			var info = $"{fpsCounter.FramesPerSecond} fps";
 			var placeSize = new D2DSize(1000, 1000);
 			var size = graphics.MeasureText(info, Font.Name, Font.Size, placeSize);
-			graphics.DrawText(info, D2DColor.Silver, ClientRectangle.Right - size.Width - 10, 5);
+			graphics.DrawText(info, D2DColor.Silver, ClientRectangle.Right - size.width - 10, 5);
 		}
 
 		protected override void WndProc(ref System.Windows.Forms.Message m)

--- a/src/D2DWinForm/D2DWinForm.cs
+++ b/src/D2DWinForm/D2DWinForm.cs
@@ -122,7 +122,7 @@ namespace unvell.D2DLib.WinForm
 		{
 			// prevent the .NET windows form to paint the original background
 		}
-		
+
 		protected override void OnPaint(System.Windows.Forms.PaintEventArgs e)
 		{
 			if (this.DesignMode)
@@ -133,7 +133,9 @@ namespace unvell.D2DLib.WinForm
 			else
 			{
 				if (ShowFPS)
+				{
 					fpsSW.Start();
+				}
 
 				Assumes.NotNull(this.graphics);
 
@@ -146,13 +148,13 @@ namespace unvell.D2DLib.WinForm
 					this.graphics.BeginRender(D2DColor.FromGDIColor(this.BackColor));
 				}
 
-				
+
 				OnRender(this.graphics);
 
 				if (ShowFPS)
 				{
 					++frameCounter;
-					if(fpsSW.ElapsedMilliseconds >= 1000)
+					if (fpsSW.ElapsedMilliseconds >= 1000)
 					{
 						int fps = (int)((frameCounter * TimeSpan.TicksPerSecond) / fpsSW.ElapsedTicks);
 						lastFPSValue = fps;

--- a/src/D2DWinForm/D2DWinForm.cs
+++ b/src/D2DWinForm/D2DWinForm.cs
@@ -66,6 +66,7 @@ namespace unvell.D2DLib.WinForm
 
 		private int frameCounter = 0, lastFPSValue;
 		public bool ShowFPS { get; set; }
+		protected virtual int FPS => lastFPSValue;
 
 		private Timer timer = new Timer() { Interval = 10 };
 		public bool EscapeKeyToClose { get; set; } = true;

--- a/src/Examples/Examples.csproj
+++ b/src/Examples/Examples.csproj
@@ -67,4 +67,10 @@
     <Using Include="System.Windows.Forms" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="SampleCode\MeasureAndDrawStringForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/src/Examples/SampleCode/MeasureAndDrawStringForm.cs
+++ b/src/Examples/SampleCode/MeasureAndDrawStringForm.cs
@@ -33,70 +33,21 @@ namespace unvell.D2DLib.Examples.SampleCode
 			Text = "Measure and draw string";
 
 			Size = new Size(1280, 800);
-			brush = Device.CreateSolidColorTextBrush(D2DColor.BlueViolet);
-			brushBack = Device.CreateSolidColorBrush(D2DColor.DarkGray);
-			fontFormat = Device.CreateFontFormat(Font.Name, 34);
-
-			szString = new D2DSize(60, 20);
-			dispstrings = new List<string>(2000);
-			AnimationDraw = true;
-			ShowFPS = true;
-
-			CreateStrings();
 		}
 
-
-		D2DSize szString;
-		D2DSolidColorTextBrush brush;
-		D2DSolidColorBrush brushBack;
-		D2DFontFormat fontFormat;
-
-		List<string> dispstrings;
-		D2DPoint ptLeftTop = new D2DPoint(0, 0);
-		D2DRect rect = new D2DRect(0, 0, 0, 0);
-
-		private void CreateStrings()
-        {
-			for (int count = 0; count < 1000; ++count)
-            {
-				dispstrings.Add(Guid.NewGuid().ToString().Substring(20, 8));
-			}
-		}
-
-        protected override void OnFrame()
-        {
-            base.OnFrame();
-		}
-
-        protected override void OnRender(D2DGraphics g)
+		protected override void OnRender(D2DGraphics g)
 		{
-			g.FillRectangle(ClientRectangle, brushBack);
-			var ratio = (double)(ClientRectangle.Width) / ClientRectangle.Height;
-			
-			for (int i = 0; i < dispstrings.Count; i++)
-            {
-				var str = dispstrings[i];
-				var rectSize = new D2DSize(500, 200);
-				g.MeasureText(str, fontFormat, ref rectSize); //cached textFormat
-				//var sz = g.MeasureText(str, font1.Name, font1.Size, new D2DSize(999,200)); //not cached
+			var text = "Hello World";
 
-				rect.left = (rect.left + rect.Width + rectSize.width) % (ClientSize.Width );
-				rect.top = (rect.top + rect.Height + rectSize.height) % (ClientSize.Height );
-				rect.Width = rectSize.width;
-				rect.Height = rectSize.height;
+			var rect = new Rectangle(100, 100, 500, 500);
 
-				//g.DrawText(str, D2DColor.BlueViolet, font1.Name, font1.Size, rect); //32 fps + measure text not cached
-				g.DrawText(str, brush, fontFormat, ref rect ); //45fps + measure text not cached, 64fp with measure text cached
-			}
+			var measuredSize = g.MeasureText(text, font1.Name, font1.Size, rect.Size);
+
+			var measuredRect = new D2DRect(rect.X, rect.Y, measuredSize.width, measuredSize.height);
+
+			g.DrawText(text, D2DColor.Black, font1.Name, font1.Size, rect);
+
+			g.DrawRectangle(measuredRect, D2DColor.Blue);
 		}
-        protected override void OnFormClosed(FormClosedEventArgs e)
-        {
-            base.OnFormClosed(e);
-			brush.Dispose();
-			brushBack.Dispose();
-			fontFormat.Dispose();
-		}
-        
-    }
+	}
 }
-

--- a/src/Examples/SampleCode/MeasureAndDrawStringWithCachedFontFormatForm.cs
+++ b/src/Examples/SampleCode/MeasureAndDrawStringWithCachedFontFormatForm.cs
@@ -1,0 +1,174 @@
+﻿/*
+ * MIT License
+ * 
+ * Copyright (c) 2009-2021 Jingwood, unvell.com. All right reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace unvell.D2DLib.Examples.SampleCode
+{
+	public partial class MeasureAndDrawStringWithCachedFontFormatForm : ExampleForm
+	{
+		private static readonly Font font1 = new Font("Times New Roman", 34f, FontStyle.Italic);
+
+		public MeasureAndDrawStringWithCachedFontFormatForm()
+		{
+			Text = "Measure and draw string";
+
+			Size = new Size(1280, 800);
+			brush = Device.CreateSolidColorTextBrush(D2DColor.BlueViolet);
+			brushBack = Device.CreateSolidColorBrush(D2DColor.DarkGray);
+			fontFormat = Device.CreateFontFormat(Font.Name, 34);
+
+			szString = new D2DSize(60, 20);
+			dispstrings = new List<string>(2000);
+			AnimationDraw = true;
+			ShowFPS = true;
+
+			CreateStrings();
+		}
+
+
+		D2DSize szString;
+		D2DSolidColorTextBrush brush;
+		D2DSolidColorBrush brushBack;
+		D2DFontFormat fontFormat;
+
+		List<string> dispstrings;
+		D2DPoint ptLeftTop = new D2DPoint(0, 0);
+		D2DRect rect = new D2DRect(0, 0, 0, 0);
+
+		SimpleCheckBox checkbox = new SimpleCheckBox();
+
+
+		private void CreateStrings()
+		{
+			for (int count = 0; count < 1000; ++count)
+			{
+				dispstrings.Add(Guid.NewGuid().ToString().Substring(20, 8));
+			}
+		}
+
+		protected override void OnFrame()
+		{
+			base.OnFrame();
+		}
+
+		protected override void OnRender(D2DGraphics g)
+		{
+			g.FillRectangle(ClientRectangle, brushBack);
+			var ratio = (double)(ClientRectangle.Width) / ClientRectangle.Height;
+
+			for (int i = 0; i < dispstrings.Count; i++)
+			{
+				var str = dispstrings[i];
+				var rectSize = new D2DSize(500, 200);
+
+				if (checkbox.IsChecked)
+				{
+					g.MeasureText(str, fontFormat, ref rectSize); //cached textFormat
+				}
+				else
+				{
+					var sz = g.MeasureText(str, font1.Name, font1.Size, new D2DSize(999, 200)); //not cached
+				}
+
+				rect.left = (rect.left + rect.Width + rectSize.width) % (ClientSize.Width);
+				rect.top = (rect.top + rect.Height + rectSize.height) % (ClientSize.Height);
+				rect.Width = rectSize.width;
+				rect.Height = rectSize.height;
+
+				if (checkbox.IsChecked)
+				{
+					g.DrawText(str, brush, fontFormat, ref rect); //45fps + measure text not cached, 64fp with measure text cached
+				}
+				else
+				{
+					g.DrawText(str, D2DColor.BlueViolet, font1.Name, font1.Size, rect); //32 fps + measure text not cached
+				}
+			}
+
+
+			// UI
+			//g.FillRectangle(10, 10, 600, 80, D2DColor.White);
+			checkbox.OnRender(g);
+
+			g.DrawStrokedText($"{this.FPS} FPS", 20, 60, D2DColor.White, 2, D2DColor.DarkBlue, "Arial", 24, D2DFontWeight.SemiBold);
+		}
+
+		protected override void OnMouseDown(MouseEventArgs e)
+		{
+			base.OnMouseDown(e);
+
+			checkbox.OnMouseDown(e);
+			Invalidate();
+		}
+
+		protected override void OnFormClosed(FormClosedEventArgs e)
+		{
+			base.OnFormClosed(e);
+			brush.Dispose();
+			brushBack.Dispose();
+			fontFormat.Dispose();
+		}
+	}
+
+	public class SimpleCheckBox
+	{
+
+		public SimpleCheckBox()
+		{
+			this.CheckBounds = new Rectangle(200, 30, 40, 40);
+			this.Bounds = new Rectangle(this.CheckBounds.X - Padding, this.CheckBounds.Y - Padding, 400, this.CheckBounds.Height + Padding * 2);
+		}
+
+		public int Padding { get; set; } = 20;
+		public Rectangle Bounds { get; set; }
+		public Rectangle CheckBounds { get; set; }
+
+		public bool IsChecked { get; set; } = true;
+
+		public void OnRender(D2DGraphics g)
+		{
+			g.FillRectangle(Bounds, new D2DColor(.9f, D2DColor.Silver));
+			g.FillRectangle(CheckBounds, D2DColor.White);
+			g.DrawRectangle(CheckBounds, D2DColor.Black);
+			g.DrawText("Using Cached Font Format", D2DColor.Black, "Arial", 24f, CheckBounds.Right + Padding, Bounds.Y + Bounds.Height / 2 - 12);
+
+			if (IsChecked)
+			{
+				g.DrawLines(new Vector2[] {
+					new Vector2(CheckBounds.X + 4, CheckBounds.Y + CheckBounds.Height / 2),
+					new Vector2(CheckBounds.X + CheckBounds.Width / 2, CheckBounds.Bottom - 4),
+					new Vector2(CheckBounds.Right - 4, CheckBounds.Y + 4),
+				}, D2DColor.DarkSeaGreen, 3);
+			}
+		}
+
+		public virtual void OnMouseDown(MouseEventArgs e)
+		{
+			if (e.Button == MouseButtons.Left && CheckBounds.Contains(e.Location))
+			{
+				IsChecked = !IsChecked;
+			}
+		}
+	}
+}
+

--- a/src/Examples/SampleCode/MeasureAndDrawStringWithCachedFontFormatForm.cs
+++ b/src/Examples/SampleCode/MeasureAndDrawStringWithCachedFontFormatForm.cs
@@ -30,7 +30,7 @@ namespace unvell.D2DLib.Examples.SampleCode
 
 		public MeasureAndDrawStringWithCachedFontFormatForm()
 		{
-			Text = "Measure and draw string";
+			Text = "Measure and draw string performance comparison";
 
 			Size = new Size(1280, 800);
 			brush = Device.CreateSolidColorTextBrush(D2DColor.BlueViolet);


### PR DESCRIPTION
Some minor improvements for [PR108](https://github.com/jingwood/d2dlib/pull/108)
- Fix PInvoke Exception on some x86 environment 
- Restore the original sample of measure and draw text (that shows how to measure a string)
- Measure and draw text sample program improvements (See below picture)
- Fixed compiling errors (don't known why happened after merging the [PR108](https://github.com/jingwood/d2dlib/pull/108))

Add a checkbox to enable or disable for using cached font format
![image](https://github.com/user-attachments/assets/6ffc519a-0cb2-42fb-a24d-d34432f33074)

When checked, FPS value is about 60, without checked, FPS dropped to about 40.
