### PR TITLE
Set D2DGraphic' D2DDevice handle automatically for memory bitmap to draw paths correctly

### DIFF
--- a/src/D2DLibExport/D2DGraphics.cs
+++ b/src/D2DLibExport/D2DGraphics.cs
@@ -31,7 +31,7 @@ namespace unvell.D2DLib
 	{
 		internal HANDLE Handle { get; }
 
-		public D2DDevice? Device { get; }
+		public D2DDevice Device { get; }
 
 		public D2DGraphics(D2DDevice context)
 			: this(context.Handle)
@@ -42,7 +42,8 @@ namespace unvell.D2DLib
 		public D2DGraphics(HANDLE handle)
 		{
 			this.Handle = handle;
-		}
+			this.Device = new D2DDevice(handle);
+        }
 
 		public void BeginRender()
 		{


### PR DESCRIPTION
Fixes #81 

This pull request includes changes to the `D2DGraphics` class in the `src/D2DLibExport/D2DGraphics.cs` file to improve the handling of the `Device` property. The most important changes are:

* [`src/D2DLibExport/D2DGraphics.cs`](diffhunk://#diff-f420750dee9c83ad290281cd68e3b59bf28312a2f6a9c0d91369ed971e828a41L34-R34): Changed the `Device` property from nullable (`D2DDevice?`) to non-nullable (`D2DDevice`). This ensures that the `Device` property will always be initialized and not null.
* [`src/D2DLibExport/D2DGraphics.cs`](diffhunk://#diff-f420750dee9c83ad290281cd68e3b59bf28312a2f6a9c0d91369ed971e828a41R45): Updated the constructor `public D2DGraphics(HANDLE handle)` to initialize the `Device` property with a new `D2DDevice` instance using the provided handle.